### PR TITLE
Add materials to environment

### DIFF
--- a/website/docs/cheatsheet/data.md
+++ b/website/docs/cheatsheet/data.md
@@ -208,6 +208,9 @@ or as download:
 ```python
 data_ref = ds.path('<path/on/datastore>').as_download()
 ```
+:::info
+To mount a datastore the workspace need to have read and write access to the underlying storage. For readonly datastore `as_download` is the only option. 
+:::
 
 #### Consume DataReference in ScriptRunConfig
 

--- a/website/docs/cheatsheet/distributed-training.md
+++ b/website/docs/cheatsheet/distributed-training.md
@@ -112,10 +112,7 @@ Despite the name, environment variable OMPI_COMM_WORLD_NODE_RANK does not corres
 
 The following code maps the OpenMPI environment variables to PyTorch style. For majority of the pytorch script, simply call `set_environment_variables_for_nccl_backend()` function before your script calls `torch.distributed.init_process_group`. If your script passes in information like local_rank or rank as script arguments, just remove these and use provided helper functions `get_local_rank()` and `get_rank()` instead.
 
-```python 
-###########################
-# aml_mpienv.py
-###########################
+```python title="aml_mpienv.py"
 import os
 
 def set_environment_variables_for_nccl_backend(master_port=6105, verbose=True):
@@ -201,8 +198,7 @@ experiment = Experiment(ws, "pt_dist_launch")
 experiment.submit(run)
 ```
 
-```python
-# train.py
+```python title="train.py"
 from aml_mpienv import set_environment_variables_for_nccl_backend, get_local_rank
 
 set_environment_variables_for_nccl_backend()
@@ -245,9 +241,9 @@ run = ScriptRunConfig(
 experiment = Experiment(ws, "pt_dist_launch")
 experiment.submit(run)
 ```
-#### launch.py
 
-```python
+
+```python title="launch.py"
 #####################################################################################
 # launch.py
 # based on https://github.com/pytorch/pytorch/blob/master/torch/distributed/launch.py
@@ -399,9 +395,7 @@ if __name__ == "__main__":
     main()
 ```
 
-#### example.py
-
-```python
+```python title="example.py"
 # example.py 
 import argparse
 import os
@@ -433,7 +427,7 @@ To launch training script directly without launch.py, remember the key is to set
 Make sure to call `set_environment_variables_for_nccl_backend` and set `local_rank` __right after the TrainingArguments object is created__. 
 :::
 
-```python
+```python title="run_glue.py"
 #####################################################################################################
 ## https://github.com/huggingface/transformers/blob/master/examples/text-classification/run_glue.py
 #####################################################################################################

--- a/website/docs/cheatsheet/environment.md
+++ b/website/docs/cheatsheet/environment.md
@@ -377,9 +377,9 @@ In this case you need to:
 env = Environment('pytorch')    # create an Environment called 'pytorch'
 
 # set up custom docker image or a dockerfile
-env.docker.base_image = "mcr.microsoft.com/azureml/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04"
+# env.docker.base_image = "mcr.microsoft.com/azureml/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04"
 # or set up base image from a dockerfile
-# env.docker.base_dockerfile = "./Dockerfile"
+env.docker.base_dockerfile = "./Dockerfile"
 
 # indicate how to run Python
 env.python.user_managed_dependencies=True


### PR DESCRIPTION
- add an intro section with overview of environment management options
- add a few snippets for custom docker images, e.g. private acr, build_local, etc. 
- modified the shell script approach with proper process sync guard
