### PR TITLE
Sample browser metadata explore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 page_type: sample
 languages:
 - python
+- azurecli
 products:
 - azure-machine-learning
+description: Top-level directory for official Azure Machine Learning sample code and notebooks.
 ---
 # Azure Machine Learning Examples
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!--
 ---
 page_type: sample
 languages:
@@ -7,6 +8,8 @@ products:
 - azure-machine-learning
 description: Top-level directory for official Azure Machine Learning sample code and notebooks.
 ---
+-->
+
 # Azure Machine Learning Examples
 
 [![smoke](https://github.com/Azure/azureml-examples/workflows/smoke/badge.svg)](https://github.com/Azure/azureml-examples/actions?query=workflow%3Asmoke)

--- a/prefix.md
+++ b/prefix.md
@@ -2,8 +2,10 @@
 page_type: sample
 languages:
 - python
+- azurecli
 products:
 - azure-machine-learning
+description: Top-level directory for official Azure Machine Learning sample code and notebooks.
 ---
 # Azure Machine Learning Examples
 

--- a/prefix.md
+++ b/prefix.md
@@ -1,3 +1,4 @@
+<!--
 ---
 page_type: sample
 languages:
@@ -7,6 +8,8 @@ products:
 - azure-machine-learning
 description: Top-level directory for official Azure Machine Learning sample code and notebooks.
 ---
+-->
+
 # Azure Machine Learning Examples
 
 [![smoke](https://github.com/Azure/azureml-examples/workflows/smoke/badge.svg)](https://github.com/Azure/azureml-examples/actions?query=workflow%3Asmoke)


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [ X ] read and followed the contributing guidelines
- [ X ] ran `python readme.py` after making changes (per contributing guidelines)
- [ ] added required testing (per contributing guidelines)

## Changes

- Added a new key to YAML frontmatter: `description` which I believe becomes the contents of the card on the sample browser

- Wrapped the YAML frontmatter in HTML comment <!-- -->, which is a hack that can hide Markdown. However, if the d.m.c. samples process is hard-coded to expect `---` as the opening line, we won't be able to get away with this.

fixes #
