### PR TITLE
Use defaultCallBack instead of AzureMLCallBack

### DIFF
--- a/workflows/train/deepspeed/transformers/src/finetune_glue.py
+++ b/workflows/train/deepspeed/transformers/src/finetune_glue.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
     trainer = Trainer(
         model,
         training_args,
-        callbacks=[AzureMLCallback()],
         train_dataset=encoded_dataset_train,
         eval_dataset=encoded_dataset_eval,
         tokenizer=tokenizer,


### PR DESCRIPTION
# Using AzureMLCallBack logs all metrics two times in Azure ML platform.

## Checklist

I have:

- [X] read and followed the contributing guidelines
- [ ] ran `python readme.py` after making changes (per contributing guidelines)
- [ ] added required testing (per contributing guidelines)

## Changes

-Remove the specification of using AzureMLCallBack in Trainer.

