### PR TITLE
Added Linux install az  & ml extension snippet

### DIFF
--- a/cli/misc.sh
+++ b/cli/misc.sh
@@ -9,6 +9,11 @@ az extension list
 az extension add -n ml
 # </az_ml_install>
 
+# <az_extension_install_linux>
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash 
+az extension add -n ml -y 
+# </az_extension_install_linux>
+
 # <az_ml_update>
 az extension update -n ml
 # </az_ml_update>
@@ -25,4 +30,3 @@ az account set -s "<YOUR_SUBSCRIPTION_NAME_OR_ID>"
 az extension remove -n azure-cli-ml
 az extension remove -n ml
 # </az_extension_remove>
-


### PR DESCRIPTION
This is  a shortcut to the preferred way to install the Linux version. If you do `apt install` you get a version of `az` that predates `update`.

# PR into Azure/azureml-examples

## Checklist

I have:

- [ x ] read and followed the contributing guidelines

## Changes

- Added a new snippet, based on https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt. To be referenced from "Install, set up, and use the 2.0 CLI" Problem is Linux distro of `az` is too old, so install of `ml` extension requires 3 docs to find proper way.  

fixes #

