### PR TITLE
update kernel name to python 36 for AutoML notebooks

### DIFF
--- a/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
@@ -911,7 +911,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/classification-credit-card-fraud/auto-ml-classification-credit-card-fraud.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-credit-card-fraud/auto-ml-classification-credit-card-fraud.ipynb
@@ -453,7 +453,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
@@ -560,7 +560,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/continuous-retraining/auto-ml-continuous-retraining.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/continuous-retraining/auto-ml-continuous-retraining.ipynb
@@ -565,7 +565,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-beer-remote/auto-ml-forecasting-beer-remote.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-beer-remote/auto-ml-forecasting-beer-remote.ipynb
@@ -674,7 +674,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -628,7 +628,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
@@ -717,7 +717,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-forecast-function/auto-ml-forecasting-function.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-forecast-function/auto-ml-forecasting-function.ipynb
@@ -862,7 +862,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
@@ -803,7 +803,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/local-run-classification-credit-card-fraud/auto-ml-classification-credit-card-fraud-local.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/local-run-classification-credit-card-fraud/auto-ml-classification-credit-card-fraud-local.ipynb
@@ -869,7 +869,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
@@ -952,7 +952,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/python-sdk/tutorials/automl-with-azureml/regression/auto-ml-regression.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/regression/auto-ml-regression.ipynb
@@ -450,7 +450,7 @@
   "kernelspec": {
    "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3.6"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [X] read and followed the contributing guidelines

## Changes

- updated the Kernel name of the AutoML notebooks to match the old kernel name

fixes #

