### PR TITLE
Update Triton base image to latest version

### DIFF
--- a/cli/endpoints/online/triton/ensemble/create-endpoint-with-deployment-mir.yml
+++ b/cli/endpoints/online/triton/ensemble/create-endpoint-with-deployment-mir.yml
@@ -17,7 +17,7 @@ deployments:
             name: triton-mir-endpoint
             version: 1
             docker:
-                image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210525.1
+                image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210817.v1
         environment_variables:
             AZUREML_EXTRA_REQUIREMENTS_TXT: requirements.txt
         scale_settings:

--- a/cli/endpoints/online/triton/multi-models/create-endpoint-with-deployment-mir.yml
+++ b/cli/endpoints/online/triton/multi-models/create-endpoint-with-deployment-mir.yml
@@ -17,5 +17,5 @@ deployments:
             name: triton-mir-endpoint
             version: 1
             docker:
-                image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210525.1
+                image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210817.v1
         instance_type: Standard_NC6s_v3

--- a/cli/endpoints/online/triton/single-model/create-endpoint-with-deployment-mir.yml
+++ b/cli/endpoints/online/triton/single-model/create-endpoint-with-deployment-mir.yml
@@ -17,7 +17,7 @@ deployments:
             name: triton-mir-endpoint
             version: 1
             docker:
-                image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210525.1
+                image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210817.v1
         scale_settings:
             scale_type: manual
             instance_count: 1


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [ ] read and followed the contributing guidelines

## Changes

We released new Triton base image with CELA approved license.
Updating MCR image from `image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210525.1`
to  `image: mcr.microsoft.com/azureml/tritonserver-21.02-py38-inference:20210817.v1`


