### PR TITLE
Update conda.yaml to specify version of dependencies for online endpoints

### DIFF
--- a/cli/endpoints/online/model-1/environment/conda.yml
+++ b/cli/endpoints/online/model-1/environment/conda.yml
@@ -3,13 +3,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - numpy
-  - pip
-  - scikit-learn==0.24.2
-  - scipy
+  - numpy=1.21.2
+  - pip=21.2.4
+  - scikit-learn=0.24.2
+  - scipy=1.7.1
   - pip:
-    - azureml-defaults
-    - inference-schema[numpy-support]
-    - joblib
-    - numpy
-    - scipy
+    - azureml-defaults==1.33.0
+    - inference-schema[numpy-support]==1.3.0
+    - joblib==1.0.1

--- a/cli/endpoints/online/model-2/environment/conda.yml
+++ b/cli/endpoints/online/model-2/environment/conda.yml
@@ -3,13 +3,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - numpy
-  - pip
-  - scikit-learn==0.24.2
-  - scipy
+  - numpy=1.21.2
+  - pip=21.2.4
+  - scikit-learn=0.24.2
+  - scipy=1.7.1
   - pip:
-    - azureml-defaults
-    - inference-schema[numpy-support]
-    - joblib
-    - numpy
-    - scipy
+    - azureml-defaults==1.33.0
+    - inference-schema[numpy-support]==1.3.0
+    - joblib==1.0.1


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [X] read and followed the contributing guidelines

## Changes

- Latest pip resolver struggles to resolve your not pinned dependencies. Pinning proper versions for online endpoints.

fixes #

