### PR TITLE
Fixing closing region tag

### DIFF
--- a/cli/batch-score-rest.sh
+++ b/cli/batch-score-rest.sh
@@ -105,7 +105,7 @@ response=$(curl --location --request PUT "https://management.azure.com/subscript
 
 # <read_condafile>
 CONDA_FILE=$(cat endpoints/batch/mnist/environment/conda.json | sed 's/"/\\"/g')
-# <read_condafile>
+# </read_condafile>
 # <create_environment>
 ENV_VERSION=$RANDOM
 response=$(curl --location --request PUT "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.MachineLearningServices/workspaces/$WORKSPACE/environments/mnist-env/versions/$ENV_VERSION?api-version=$API_VERSION" \


### PR DESCRIPTION
read_condafile section tags were not correctly closed.

# PR into Azure/azureml-examples

## Checklist

I have:

- [ x ] read and followed the contributing guidelines

## Changes

- added `/` to the closing tag for the create_conda 

fixes #

