### PR TITLE
Replace the deprecated API and use register_pandas_dataframe.

### DIFF
--- a/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
@@ -233,19 +233,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from azureml.core import Dataset\n",
+    "from azureml.data.dataset_factory import TabularDatasetFactory\n",
     "\n",
-    "if not os.path.isdir(\"data_mm\"):\n",
-    "    os.mkdir(\"data_mm\")\n",
-    "X_train.to_csv(\"data_mm/data_train.csv\", index=False)\n",
-    "X_test.to_csv(\"data_mm/data_test.csv\", index=False)\n",
-    "# Upload saved data to the default data store.\n",
     "ds = ws.get_default_datastore()\n",
-    "Dataset.File.upload_directory(src_dir=\"./data_mm\", target=(ds, \"data_mm\"))\n",
-    "train_data = Dataset.Tabular.from_delimited_files(\n",
-    "    path=ds.path(\"data_mm/data_train.csv\")\n",
+    "# Upload saved data to the default data store.\n",
+    "train_data = TabularDatasetFactory.register_pandas_dataframe(\n",
+    "    X_train, target=(ds, \"data_mm\"), name=\"data_train\"\n",
     ")\n",
-    "test_data = Dataset.Tabular.from_delimited_files(path=ds.path(\"data_mm/data_test.csv\"))"
+    "test_data = TabularDatasetFactory.register_pandas_dataframe(\n",
+    "    X_test, target=(ds, \"data_mm\"), name=\"data_test\"\n",
+    ")"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-single-model/auto-ml-forecasting-backtest-single-model.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-single-model/auto-ml-forecasting-backtest-single-model.ipynb
@@ -60,7 +60,7 @@
     "import shutil\n",
     "\n",
     "import azureml.core\n",
-    "from azureml.core import Dataset, Experiment, Model, Workspace"
+    "from azureml.core import Experiment, Model, Workspace"
    ]
   },
   {
@@ -222,16 +222,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# We need to save the artificial data and then upload them to default workspace datastore.\n",
-    "DATA_PATH = \"data\"\n",
-    "DATA_PATH_X = \"{}/data_train.csv\".format(DATA_PATH)\n",
-    "if not os.path.isdir(\"data\"):\n",
-    "    os.mkdir(\"data\")\n",
-    "X_train.to_csv(\"data/data_train.csv\", index=False)\n",
-    "# Upload saved data to the default data store.\n",
+    "from azureml.data.dataset_factory import TabularDatasetFactory\n",
+    "\n",
     "ds = ws.get_default_datastore()\n",
-    "Dataset.File.upload_directory(src_dir=\"./data\", target=(ds, DATA_PATH))\n",
-    "train_data = Dataset.Tabular.from_delimited_files(path=ds.path(DATA_PATH_X))"
+    "# Upload saved data to the default data store.\n",
+    "train_data = TabularDatasetFactory.register_pandas_dataframe(\n",
+    "    X_train, target=(ds, \"data\"), name=\"data_backtest\"\n",
+    ")"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-hierarchical-timeseries/auto-ml-forecasting-hierarchical-timeseries.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-hierarchical-timeseries/auto-ml-forecasting-hierarchical-timeseries.ipynb
@@ -151,36 +151,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "gather": {
-     "logged": 1613005886349
-    },
-    "jupyter": {
-     "outputs_hidden": false,
-     "source_hidden": false
-    },
-    "nteract": {
-     "transient": {
-      "deleting": false
-     }
-    }
-   },
-   "outputs": [],
-   "source": [
-    "datastore.upload(\n",
-    "    src_dir=\"./Data/\", target_path=datastore_path, overwrite=True, show_progress=True\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Create the TabularDatasets \n",
     "\n",
-    "Datasets in Azure Machine Learning are references to specific data in a Datastore. The data can be retrieved as a [TabularDatasets](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.data.tabulardataset?view=azure-ml-py)."
+    "Datasets in Azure Machine Learning are references to specific data in a Datastore. The data can be retrieved as a [TabularDatasets](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.data.tabulardataset?view=azure-ml-py). We will read in the data as a pandas DataFrame, upload to the data store and register them to your Workspace using ```register_pandas_dataframe``` so they can be called as an input into the training pipeline. We will use the inference dataset as part of the forecasting pipeline. The step need only be completed once."
    ]
   },
   {
@@ -193,32 +169,18 @@
    },
    "outputs": [],
    "source": [
-    "from azureml.core.dataset import Dataset\n",
+    "from azureml.data.dataset_factory import TabularDatasetFactory\n",
     "\n",
-    "train_ds = Dataset.Tabular.from_delimited_files(\n",
-    "    path=datastore.path(\"hts-sample/hts-sample-train.csv\"), validate=False\n",
+    "registered_train = TabularDatasetFactory.register_pandas_dataframe(\n",
+    "    pd.read_csv(\"Data/hts-sample-train.csv\"),\n",
+    "    target=(datastore, \"hts-sample\"),\n",
+    "    name=\"hts-sales-train\",\n",
     ")\n",
-    "inference_ds = Dataset.Tabular.from_delimited_files(\n",
-    "    path=datastore.path(\"hts-sample/hts-sample-test.csv\"), validate=False\n",
+    "registered_inference = TabularDatasetFactory.register_pandas_dataframe(\n",
+    "    pd.read_csv(\"Data/hts-sample-test.csv\"),\n",
+    "    target=(datastore, \"hts-sample\"),\n",
+    "    name=\"hts-sales-test\",\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Register the TabularDatasets to the Workspace \n",
-    "Finally, register the dataset to your Workspace so it can be called as an input into the training pipeline. We will use the inference dataset as part of the forecasting pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "registered_train = train_ds.register(ws, \"hts-sales-train\")\n",
-    "registered_inference = inference_ds.register(ws, \"hts-sales-test\")"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
@@ -537,7 +537,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieving  forecasts from the model\n",
+    "### Retrieving forecasts from the model\n",
     "We have created a function called `run_forecast` that submits the test data to the best model determined during the training run and retrieves forecasts. This function uses a helper script `forecasting_script` which is uploaded and expecuted on the remote compute."
    ]
   },

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
@@ -537,7 +537,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retreiving forecasts from the model\n",
+    "### Retrieving  forecasts from the model\n",
     "We have created a function called `run_forecast` that submits the test data to the best model determined during the training run and retrieves forecasts. This function uses a helper script `forecasting_script` which is uploaded and expecuted on the remote compute."
    ]
   },

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
@@ -261,22 +261,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train.to_csv(r\"./dominicks_OJ_train.csv\", index=None, header=True)\n",
-    "test.to_csv(r\"./dominicks_OJ_test.csv\", index=None, header=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from azureml.data.dataset_factory import TabularDatasetFactory\n",
+    "\n",
     "datastore = ws.get_default_datastore()\n",
-    "datastore.upload_files(\n",
-    "    files=[\"./dominicks_OJ_train.csv\", \"./dominicks_OJ_test.csv\"],\n",
-    "    target_path=\"dataset/\",\n",
-    "    overwrite=True,\n",
-    "    show_progress=True,\n",
+    "train_dataset = TabularDatasetFactory.register_pandas_dataframe(\n",
+    "    train, target=(datastore, \"dataset/\"), name=\"dominicks_OJ_train\"\n",
+    ")\n",
+    "test_dataset = TabularDatasetFactory.register_pandas_dataframe(\n",
+    "    test, target=(datastore, \"dataset/\"), name=\"dominicks_OJ_test\"\n",
     ")"
    ]
   },
@@ -285,22 +277,6 @@
    "metadata": {},
    "source": [
     "### Create dataset for training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from azureml.core.dataset import Dataset\n",
-    "\n",
-    "train_dataset = Dataset.Tabular.from_delimited_files(\n",
-    "    path=datastore.path(\"dataset/dominicks_OJ_train.csv\")\n",
-    ")\n",
-    "test_dataset = Dataset.Tabular.from_delimited_files(\n",
-    "    path=datastore.path(\"dataset/dominicks_OJ_test.csv\")\n",
-    ")"
    ]
   },
   {
@@ -561,7 +537,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieving forecasts from the model\n",
+    "### Retreiving forecasts from the model\n",
     "We have created a function called `run_forecast` that submits the test data to the best model determined during the training run and retrieves forecasts. This function uses a helper script `forecasting_script` which is uploaded and expecuted on the remote compute."
    ]
   },


### PR DESCRIPTION
…of upload method.

# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

-The deprecated Datastore.upload_files() API was replaced by TabularDatasetFactory.register_pandas_dataframe.

fixes #

