### PR TITLE
Avoid local model unpickling

### DIFF
--- a/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
@@ -610,7 +610,7 @@
     "\n",
     "### Retrieve the Best Model\n",
     "\n",
-    "Below we select the best pipeline from our iterations.  The `get_best_child` method returns the Run object for the best model based on the default primary metric. There are additional flags that can be passed to the method if we want to retrieve the best Run based on any of the other supported metrics, or if we are just interested in the best run among the ONNX compatible runs. As always, you can execute `remote_run.get_best_child??` in a new cell to view the source or docs for the function."
+    "Below we select the best pipeline from our iterations.  The `get_best_child` method returns the Run object for the best model based on the default primary metric. There are additional flags that can be passed to the method if we want to retrieve the best Run based on any of the other supported metrics, or if we are just interested in the best run among the ONNX compatible runs. As always, you can execute `??remote_run.get_best_child` in a new cell to view the source or docs for the function."
    ]
   },
   {
@@ -619,7 +619,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "remote_run.get_best_child??"
+    "??remote_run.get_best_child"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
@@ -421,7 +421,9 @@
    "outputs": [],
    "source": [
     "# Download the featurization summary JSON file locally\n",
-    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/featurization_summary.json\", \"featurization_summary.json\"\n",
+    ")\n",
     "\n",
     "# Render the JSON as a pandas DataFrame\n",
     "with open(\"featurization_summary.json\", \"r\") as f:\n",

--- a/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
@@ -637,7 +637,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run, fitted_model = remote_run.get_output()"
+    "best_run = remote_run.get_best_child()"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
@@ -929,5 +929,5 @@
   "task": "Classification"
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-bank-marketing-all-features/auto-ml-classification-bank-marketing-all-features.ipynb
@@ -61,6 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import logging\n",
     "\n",
     "from matplotlib import pyplot as plt\n",
@@ -149,7 +150,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
@@ -346,7 +349,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Call the `submit` method on the experiment object and pass the run configuration. Execution of local runs is synchronous. Depending on the data and the number of iterations this can run for a while. Validation errors and current status will be shown when setting `show_output=True` and the execution will be synchronous."
    ]
@@ -362,7 +367,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Run the following cell to access previous runs. Uncomment the cell below and update the run_id."
    ]
@@ -394,7 +401,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run_customized, fitted_model_customized = remote_run.get_output()"
+    "# Retrieve the best Run object\n",
+    "best_run = remote_run.get_best_child()"
    ]
   },
   {
@@ -403,7 +411,7 @@
    "source": [
     "## Transparency\n",
     "\n",
-    "View updated featurization summary"
+    "View featurization summary for the best model - to study how different features were transformed. This is stored as a JSON file in the outputs directory for the run."
    ]
   },
   {
@@ -412,36 +420,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "custom_featurizer = fitted_model_customized.named_steps[\"datatransformer\"]\n",
-    "df = custom_featurizer.get_featurization_summary()\n",
-    "pd.DataFrame(data=df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Set `is_user_friendly=False` to get a more detailed summary for the transforms being applied."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = custom_featurizer.get_featurization_summary(is_user_friendly=False)\n",
-    "pd.DataFrame(data=df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = custom_featurizer.get_stats_feature_type_summary()\n",
-    "pd.DataFrame(data=df)"
+    "# Download the featurization summary JSON file locally\n",
+    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "\n",
+    "# Render the JSON as a pandas DataFrame\n",
+    "with open(\"featurization_summary.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "\n",
+    "pd.DataFrame.from_records(records)"
    ]
   },
   {
@@ -487,7 +473,7 @@
     "model_explainability_run.wait_for_completion()\n",
     "\n",
     "# Get the best run object\n",
-    "best_run, fitted_model = remote_run.get_output()"
+    "best_run = remote_run.get_best_child()"
    ]
   },
   {
@@ -622,7 +608,16 @@
     "\n",
     "### Retrieve the Best Model\n",
     "\n",
-    "Below we select the best pipeline from our iterations.  The `get_output` method returns the best run and the fitted model. Overloads on `get_output` allow you to retrieve the best run and fitted model for *any* logged metric or for a particular *iteration*."
+    "Below we select the best pipeline from our iterations.  The `get_best_child` method returns the Run object for the best model based on the default primary metric. There are additional flags that can be passed to the method if we want to retrieve the best Run based on any of the other supported metrics, or if we are just interested in the best run among the ONNX compatible runs. As always, you can execute `remote_run.get_best_child??` in a new cell to view the source or docs for the function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote_run.get_best_child??"
    ]
   },
   {
@@ -934,5 +929,5 @@
   "task": "Classification"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
@@ -361,14 +361,16 @@
    "outputs": [],
    "source": [
     "# Download the featurization summary JSON file locally\n",
-    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/featurization_summary.json\", \"featurization_summary.json\"\n",
+    ")\n",
     "\n",
     "# Render the JSON as a pandas DataFrame\n",
     "with open(\"featurization_summary.json\", \"r\") as f:\n",
     "    records = json.load(f)\n",
     "\n",
     "featurization_summary = pd.DataFrame.from_records(records)\n",
-    "featurization_summary['Transformations'].tolist()"
+    "featurization_summary[\"Transformations\"].tolist()"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
@@ -585,5 +585,5 @@
   "task": "Text featurization using DNNs for classification"
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/classification-text-dnn/auto-ml-classification-text-dnn.ipynb
@@ -47,6 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import logging\n",
     "import os\n",
     "import shutil\n",
@@ -332,8 +333,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can test the model locally to get a feel of the input/output. When the model contains BERT, this step will require pytorch and pytorch-transformers installed in your local environment. The exact versions of these packages can be found in the **automl_env.yml** file located in the local copy of your MachineLearningNotebooks folder here:\n",
-    "MachineLearningNotebooks/how-to-use-azureml/automated-machine-learning/automl_env.yml"
+    "For local inferencing, you can load the model locally via. the method `remote_run.get_output()`. For more information on the arguments expected by this method, you can run `remote_run.get_output??`.\n",
+    "Note that when the model contains BERT, this step will require pytorch and pytorch-transformers installed in your local environment. The exact versions of these packages can be found in the **automl_env.yml** file located in the local copy of your azureml-examples folder here: \"azureml-examples/python-sdk/tutorials/automl-with-azureml\""
    ]
   },
   {
@@ -342,7 +343,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run, fitted_model = automl_run.get_output()"
+    "# Retrieve the best Run object\n",
+    "best_run = automl_run.get_best_child()"
    ]
   },
   {
@@ -358,12 +360,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "text_transformations_used = []\n",
-    "for column_group in fitted_model.named_steps[\n",
-    "    \"datatransformer\"\n",
-    "].get_featurization_summary():\n",
-    "    text_transformations_used.extend(column_group[\"Transformations\"])\n",
-    "text_transformations_used"
+    "# Download the featurization summary JSON file locally\n",
+    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "\n",
+    "# Render the JSON as a pandas DataFrame\n",
+    "with open(\"featurization_summary.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "\n",
+    "featurization_summary = pd.DataFrame.from_records(records)\n",
+    "featurization_summary['Transformations'].tolist()"
    ]
   },
   {
@@ -580,5 +585,5 @@
   "task": "Text featurization using DNNs for classification"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -428,7 +428,9 @@
    "outputs": [],
    "source": [
     "# Download the JSON file locally\n",
-    "best_run.download_file(\"outputs/engineered_feature_names.json\", \"engineered_feature_names.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/engineered_feature_names.json\", \"engineered_feature_names.json\"\n",
+    ")\n",
     "with open(\"engineered_feature_names.json\", \"r\") as f:\n",
     "    records = json.load(f)\n",
     "\n",
@@ -457,15 +459,25 @@
    "outputs": [],
    "source": [
     "# Download the featurization summary JSON file locally\n",
-    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/featurization_summary.json\", \"featurization_summary.json\"\n",
+    ")\n",
     "\n",
     "# Render the JSON as a pandas DataFrame\n",
     "with open(\"featurization_summary.json\", \"r\") as f:\n",
     "    records = json.load(f)\n",
     "fs = pd.DataFrame.from_records(records)\n",
     "\n",
-    "# View a summary of the featurization \n",
-    "fs[[\"RawFeatureName\", \"TypeDetected\", \"Dropped\", \"EngineeredFeatureCount\", \"Transformations\"]]"
+    "# View a summary of the featurization\n",
+    "fs[\n",
+    "    [\n",
+    "        \"RawFeatureName\",\n",
+    "        \"TypeDetected\",\n",
+    "        \"Dropped\",\n",
+    "        \"EngineeredFeatureCount\",\n",
+    "        \"Transformations\",\n",
+    "    ]\n",
+    "]"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -64,15 +64,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import azureml.core\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
+    "import json\n",
     "import logging\n",
-    "\n",
-    "from azureml.core import Workspace, Experiment, Dataset\n",
-    "from azureml.train.automl import AutoMLConfig\n",
     "from datetime import datetime\n",
-    "from azureml.automl.core.featurization import FeaturizationConfig"
+    "\n",
+    "import azureml.core\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from azureml.automl.core.featurization import FeaturizationConfig\n",
+    "from azureml.core import Dataset, Experiment, Workspace\n",
+    "from azureml.train.automl import AutoMLConfig"
    ]
   },
   {
@@ -397,8 +398,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieve the Best Model\n",
-    "Below we select the best model from all the training iterations using get_output method."
+    "### Retrieve the Best Run details\n",
+    "Below we retrieve the best Run object from among all the runs in the experiment."
    ]
   },
   {
@@ -407,8 +408,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run, fitted_model = remote_run.get_output()\n",
-    "fitted_model.steps"
+    "best_run = remote_run.get_best_child()\n",
+    "best_run"
    ]
   },
   {
@@ -417,7 +418,7 @@
    "source": [
     "## Featurization\n",
     "\n",
-    "You can access the engineered feature names generated in time-series featurization. Note that a number of named holiday periods are represented. We recommend that you have at least one year of data when using this feature to ensure that all yearly holidays are captured in the training featurization."
+    "We can look at the engineered feature names generated in time-series featurization via. the JSON file named 'engineered_feature_names.json' under the run outputs. Note that a number of named holiday periods are represented. We recommend that you have at least one year of data when using this feature to ensure that all yearly holidays are captured in the training featurization."
    ]
   },
   {
@@ -426,7 +427,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fitted_model.named_steps[\"timeseriestransformer\"].get_engineered_feature_names()"
+    "# Download the JSON file locally\n",
+    "best_run.download_file(\"outputs/engineered_feature_names.json\", \"engineered_feature_names.json\")\n",
+    "with open(\"engineered_feature_names.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "\n",
+    "records"
    ]
   },
   {
@@ -450,12 +456,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the featurization summary as a list of JSON\n",
-    "featurization_summary = fitted_model.named_steps[\n",
-    "    \"timeseriestransformer\"\n",
-    "].get_featurization_summary()\n",
-    "# View the featurization summary as a pandas dataframe\n",
-    "pd.DataFrame.from_records(featurization_summary)"
+    "# Download the featurization summary JSON file locally\n",
+    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "\n",
+    "# Render the JSON as a pandas DataFrame\n",
+    "with open(\"featurization_summary.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "fs = pd.DataFrame.from_records(records)\n",
+    "\n",
+    "# View a summary of the featurization \n",
+    "fs[[\"RawFeatureName\", \"TypeDetected\", \"Dropped\", \"EngineeredFeatureCount\", \"Transformations\"]]"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
@@ -769,5 +769,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
@@ -427,7 +427,9 @@
    "outputs": [],
    "source": [
     "# Download the JSON file locally\n",
-    "best_run.download_file(\"outputs/engineered_feature_names.json\", \"engineered_feature_names.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/engineered_feature_names.json\", \"engineered_feature_names.json\"\n",
+    ")\n",
     "with open(\"engineered_feature_names.json\", \"r\") as f:\n",
     "    records = json.load(f)\n",
     "\n",
@@ -455,15 +457,25 @@
    "outputs": [],
    "source": [
     "# Download the featurization summary JSON file locally\n",
-    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/featurization_summary.json\", \"featurization_summary.json\"\n",
+    ")\n",
     "\n",
     "# Render the JSON as a pandas DataFrame\n",
     "with open(\"featurization_summary.json\", \"r\") as f:\n",
     "    records = json.load(f)\n",
     "fs = pd.DataFrame.from_records(records)\n",
     "\n",
-    "# View a summary of the featurization \n",
-    "fs[[\"RawFeatureName\", \"TypeDetected\", \"Dropped\", \"EngineeredFeatureCount\", \"Transformations\"]]"
+    "# View a summary of the featurization\n",
+    "fs[\n",
+    "    [\n",
+    "        \"RawFeatureName\",\n",
+    "        \"TypeDetected\",\n",
+    "        \"Dropped\",\n",
+    "        \"EngineeredFeatureCount\",\n",
+    "        \"Transformations\",\n",
+    "    ]\n",
+    "]"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
@@ -68,6 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import logging\n",
     "\n",
     "from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score\n",
@@ -397,8 +398,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Retrieve the Best Model\n",
-    "Below we select the best model from all the training iterations using get_output method."
+    "## Retrieve the Best Run details\n",
+    "Below we retrieve the best Run object from among all the runs in the experiment."
    ]
   },
   {
@@ -407,8 +408,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run, fitted_model = remote_run.get_output()\n",
-    "fitted_model.steps"
+    "best_run = remote_run.get_best_child()\n",
+    "best_run"
    ]
   },
   {
@@ -416,7 +417,7 @@
    "metadata": {},
    "source": [
     "## Featurization\n",
-    "You can access the engineered feature names generated in time-series featurization."
+    "We can look at the engineered feature names generated in time-series featurization via. the JSON file named 'engineered_feature_names.json' under the run outputs."
    ]
   },
   {
@@ -425,7 +426,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fitted_model.named_steps[\"timeseriestransformer\"].get_engineered_feature_names()"
+    "# Download the JSON file locally\n",
+    "best_run.download_file(\"outputs/engineered_feature_names.json\", \"engineered_feature_names.json\")\n",
+    "with open(\"engineered_feature_names.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "\n",
+    "records"
    ]
   },
   {
@@ -448,12 +454,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the featurization summary as a list of JSON\n",
-    "featurization_summary = fitted_model.named_steps[\n",
-    "    \"timeseriestransformer\"\n",
-    "].get_featurization_summary()\n",
-    "# View the featurization summary as a pandas dataframe\n",
-    "pd.DataFrame.from_records(featurization_summary)"
+    "# Download the featurization summary JSON file locally\n",
+    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "\n",
+    "# Render the JSON as a pandas DataFrame\n",
+    "with open(\"featurization_summary.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "fs = pd.DataFrame.from_records(records)\n",
+    "\n",
+    "# View a summary of the featurization \n",
+    "fs[[\"RawFeatureName\", \"TypeDetected\", \"Dropped\", \"EngineeredFeatureCount\", \"Transformations\"]]"
    ]
   },
   {
@@ -640,7 +650,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieve the Best Model"
+    "### Retrieve the Best Run details"
    ]
   },
   {
@@ -649,7 +659,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run_lags, fitted_model_lags = advanced_remote_run.get_output()"
+    "best_run_lags = remote_run.get_best_child()\n",
+    "best_run_lags"
    ]
   },
   {
@@ -758,5 +769,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
@@ -503,15 +503,25 @@
    "outputs": [],
    "source": [
     "# Download the featurization summary JSON file locally\n",
-    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/featurization_summary.json\", \"featurization_summary.json\"\n",
+    ")\n",
     "\n",
     "# Render the JSON as a pandas DataFrame\n",
     "with open(\"featurization_summary.json\", \"r\") as f:\n",
     "    records = json.load(f)\n",
     "fs = pd.DataFrame.from_records(records)\n",
     "\n",
-    "# View a summary of the featurization \n",
-    "fs[[\"RawFeatureName\", \"TypeDetected\", \"Dropped\", \"EngineeredFeatureCount\", \"Transformations\"]]"
+    "# View a summary of the featurization\n",
+    "fs[\n",
+    "    [\n",
+    "        \"RawFeatureName\",\n",
+    "        \"TypeDetected\",\n",
+    "        \"Dropped\",\n",
+    "        \"EngineeredFeatureCount\",\n",
+    "        \"Transformations\",\n",
+    "    ]\n",
+    "]"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
@@ -58,14 +58,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import azureml.core\n",
-    "import pandas as pd\n",
+    "import json\n",
     "import logging\n",
     "\n",
-    "from azureml.core.workspace import Workspace\n",
+    "import azureml.core\n",
+    "import pandas as pd\n",
+    "from azureml.automl.core.featurization import FeaturizationConfig\n",
     "from azureml.core.experiment import Experiment\n",
-    "from azureml.train.automl import AutoMLConfig\n",
-    "from azureml.automl.core.featurization import FeaturizationConfig"
+    "from azureml.core.workspace import Workspace\n",
+    "from azureml.train.automl import AutoMLConfig"
    ]
   },
   {
@@ -471,8 +472,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieve the Best Model\n",
-    "Each run within an Experiment stores serialized (i.e. pickled) pipelines from the AutoML iterations. We can now retrieve the pipeline with the best performance on the validation dataset:"
+    "### Retrieve the Best Run details\n",
+    "Below we retrieve the best Run object from among all the runs in the experiment."
    ]
   },
   {
@@ -481,9 +482,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run, fitted_model = remote_run.get_output()\n",
-    "print(fitted_model.steps)\n",
-    "model_name = best_run.properties[\"model_name\"]"
+    "best_run = remote_run.get_best_child()\n",
+    "model_name = best_run.properties[\"model_name\"]\n",
+    "best_run"
    ]
   },
   {
@@ -501,16 +502,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "custom_featurizer = fitted_model.named_steps[\"timeseriestransformer\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "custom_featurizer.get_featurization_summary()"
+    "# Download the featurization summary JSON file locally\n",
+    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "\n",
+    "# Render the JSON as a pandas DataFrame\n",
+    "with open(\"featurization_summary.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "fs = pd.DataFrame.from_records(records)\n",
+    "\n",
+    "# View a summary of the featurization \n",
+    "fs[[\"RawFeatureName\", \"TypeDetected\", \"Dropped\", \"EngineeredFeatureCount\", \"Transformations\"]]"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/forecasting-recipes-univariate/auto-ml-forecasting-univariate-recipe-run-experiment.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/forecasting-recipes-univariate/auto-ml-forecasting-univariate-recipe-run-experiment.ipynb
@@ -387,8 +387,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieve the best model\n",
-    "Below we select the best model from all the training iterations using get_output method."
+    "### Retrieve the Best Run details\n",
+    "Below we retrieve the best Run object from among all the runs in the experiment."
    ]
   },
   {
@@ -397,8 +397,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run, fitted_model = remote_run.get_output()\n",
-    "fitted_model.steps"
+    "best_run = remote_run.get_best_child()\n",
+    "best_run"
    ]
   },
   {

--- a/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
@@ -52,6 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import logging\n",
     "\n",
     "from matplotlib import pyplot as plt\n",
@@ -327,16 +328,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run, fitted_model = remote_run.get_output()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "best_run_customized, fitted_model_customized = remote_run.get_output()"
+    "# Retrieve the best Run object\n",
+    "best_run = remote_run.get_best_child()"
    ]
   },
   {
@@ -345,7 +338,7 @@
    "source": [
     "## Transparency\n",
     "\n",
-    "View updated featurization summary"
+    "View featurization summary for the best model - to study how different features were transformed. This is stored as a JSON file in the outputs directory for the run."
    ]
   },
   {
@@ -354,41 +347,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "custom_featurizer = fitted_model_customized.named_steps[\"datatransformer\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "custom_featurizer.get_featurization_summary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "is_user_friendly=False allows for more detailed summary for transforms being applied"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "custom_featurizer.get_featurization_summary(is_user_friendly=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "custom_featurizer.get_stats_feature_type_summary()"
+    "# Download the featurization summary JSON file locally\n",
+    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "\n",
+    "# Render the JSON as a pandas DataFrame\n",
+    "with open(\"featurization_summary.json\", \"r\") as f:\n",
+    "    records = json.load(f)\n",
+    "\n",
+    "pd.DataFrame.from_records(records)"
    ]
   },
   {
@@ -975,5 +941,5 @@
   "task": "Regression"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
@@ -941,5 +941,5 @@
   "task": "Regression"
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
+++ b/python-sdk/tutorials/automl-with-azureml/regression-explanation-featurization/auto-ml-regression-explanation-featurization.ipynb
@@ -348,7 +348,9 @@
    "outputs": [],
    "source": [
     "# Download the featurization summary JSON file locally\n",
-    "best_run.download_file(\"outputs/featurization_summary.json\", \"featurization_summary.json\")\n",
+    "best_run.download_file(\n",
+    "    \"outputs/featurization_summary.json\", \"featurization_summary.json\"\n",
+    ")\n",
     "\n",
     "# Render the JSON as a pandas DataFrame\n",
     "with open(\"featurization_summary.json\", \"r\") as f:\n",


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

For some notebooks, we load the model locally just to demonstrate how to load the featurization summary. This has caused a host of problems in the past (where the model trained on remoter cannot be loaded locally due to inadequate dependencies, or versions being different from what is expected). As we move to DPv2, this is partly going to be solved my loading the model inside MLFlow environments (which has their dependencies defined explicitly).
A change went in a few weeks ago which stores the featurization summary as an artefact on the run. This PR changes some of the notebooks to use these artifacts to describe featurization summary (instead of loading the model and calling methods on it).
This is a part of the transitioning we want to do as we move towards an MLFlow model, where run / model metadata (such as featurization summaries) can be accessed via. MLFlow tags.

fixes #

