### PR TITLE
updating mlflow deployment skus

### DIFF
--- a/cli/endpoints/online/mlflow/lightgbm-deployment.yaml
+++ b/cli/endpoints/online/mlflow/lightgbm-deployment.yaml
@@ -6,5 +6,5 @@ model:
   version: 1
   local_path: lightgbm-iris/model
   model_format: mlflow
-instance_type: Standard_F2s_v2
+instance_type: Standard_F4s_v2
 instance_count: 1

--- a/cli/endpoints/online/mlflow/sklearn-deployment.yaml
+++ b/cli/endpoints/online/mlflow/sklearn-deployment.yaml
@@ -6,5 +6,5 @@ model:
   version: 1
   local_path: sklearn-diabetes/model
   model_format: mlflow
-instance_type: Standard_F2s_v2
+instance_type: Standard_F4s_v2
 instance_count: 1


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Changes

Change the SKU to Standard_F4s_v2

[Bug 1607810](https://msdata.visualstudio.com/Vienna/_workitems/edit/1607810): Fix documentation in MLFlow example to not use Standard_F2s_v2 SKU and provide user facing TSG for MLFLow experience

