### PR TITLE
upgrade dependencies, use fastparquet to fix pyarrow issue

### DIFF
--- a/cli/jobs/single-step/dask/nyctaxi/conda.yml
+++ b/cli/jobs/single-step/dask/nyctaxi/conda.yml
@@ -3,21 +3,14 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.7
-  - dask==2021.8.1
-  - distributed==2021.8.1
+  - python=3.8
+  - dask==2022.2.1
+  - distributed==2022.2.1
   - pip==21.3.1
-  - adlfs==2021.10.0
   - jupyterlab
   - jupyter-server-proxy
   - pip:
-    - ray[tune]==1.9.2
-    - ray[rllib]==1.9.2
-    - ray[serve]==1.9.2
-    - xgboost_ray==0.1.6
-    - dask==2021.12.0
-    - pyarrow >= 5.0.0
-    - fsspec==2021.10.1
-    - fastparquet==0.7.2
+    - fastparquet==0.8.0
+    - fsspec==2022.2.0
     - tabulate==0.8.9
     - azureml-mlflow

--- a/cli/jobs/single-step/dask/nyctaxi/job.yml
+++ b/cli/jobs/single-step/dask/nyctaxi/job.yml
@@ -11,6 +11,7 @@ inputs:
     mode: ro_mount
 outputs:
   output_folder:
+    type: uri_folder
 environment: 
   image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
   conda_file: conda.yml

--- a/cli/jobs/single-step/dask/nyctaxi/src/prep-nyctaxi.py
+++ b/cli/jobs/single-step/dask/nyctaxi/src/prep-nyctaxi.py
@@ -227,12 +227,11 @@ start_time = time.time()
 
 # make sure that the output_path exists on all nodes of the cluster.
 # See above for how to create it on all cluster nodes.
-taxi_df.to_parquet(output_path)
+taxi_df.to_parquet(output_path, engine="fastparquet")
 
 # for debug, show output folders on all nodes
 def list_output():
     return os.listdir(output_path)
-
 
 print(c.run(list_output))
 


### PR DESCRIPTION
# PR into Azure/azureml-examples

The job in march-cli-preview branch was failing due to an I/O error. By upgrading dependencies I was able to narrow it down to a pyarrow error due to pyarrow.lib.ArrowNotImplementedError: Unhandled type for Arrow to Parquet schema conversion: duration[ns].

Switching to fastparquet backend for the parquet saving call fixed the issue.
