### PR TITLE
endpoints named by sample

### DIFF
--- a/cli/deploy-managed-online-endpoint-mlflow.sh
+++ b/cli/deploy-managed-online-endpoint-mlflow.sh
@@ -6,7 +6,7 @@ export ENDPOINT_NAME="<YOUR_ENDPOINT_NAME>"
 # </set_endpoint_name>
 
 #  endpoint name
-export ENDPOINT_NAME=endpt-`echo $RANDOM`
+export ENDPOINT_NAME=endpt-mlflow-`echo $RANDOM`
 
 # <create_endpoint>
 az ml online-endpoint create --name $ENDPOINT_NAME -f endpoints/online/mlflow/create-endpoint.yaml

--- a/cli/deploy-managed-online-endpoint.sh
+++ b/cli/deploy-managed-online-endpoint.sh
@@ -4,7 +4,7 @@ set -e
 export ENDPOINT_NAME="<YOUR_ENDPOINT_NAME>"
 # </set_endpoint_name>
 
-export ENDPOINT_NAME=endpt-`echo $RANDOM`
+export ENDPOINT_NAME=endpt-moe-`echo $RANDOM`
 
 # <create_endpoint>
 az ml online-endpoint create --name $ENDPOINT_NAME -f endpoints/online/managed/sample/endpoint.yml

--- a/cli/deploy-r.sh
+++ b/cli/deploy-r.sh
@@ -5,7 +5,7 @@ DEPLOYMENT_NAME=r-deployment
 export ENDPOINT_NAME="<YOUR_ENDPOINT_NAME>"
 # </set_endpoint_name>
 
-export ENDPOINT_NAME=endpt-`echo $RANDOM`
+export ENDPOINT_NAME=endpt-r-`echo $RANDOM`
 
 # Download model
 wget https://aka.ms/r-model -O $BASE_PATH/scripts/model.rds

--- a/cli/deploy-rest.sh
+++ b/cli/deploy-rest.sh
@@ -13,7 +13,7 @@ TOKEN=$(az account get-access-token --query accessToken -o tsv)
 #</get_access_token>
 
 # <set_endpoint_name>
-export ENDPOINT_NAME=endpt-`echo $RANDOM`
+export ENDPOINT_NAME=endpt-rest-`echo $RANDOM`
 # </set_endpoint_name>
 
 #<api_version>

--- a/cli/deploy-safe-rollout-k8s-online-endpoints.sh
+++ b/cli/deploy-safe-rollout-k8s-online-endpoints.sh
@@ -5,7 +5,7 @@ export ENDPOINT_NAME="<YOUR_ENDPOINT_NAME>"
 # </set_endpoint_name>
 
 #  endpoint name
-export ENDPOINT_NAME=endpt-`echo $RANDOM`
+export ENDPOINT_NAME=endpt-k8s-`echo $RANDOM`
 
 # <create_endpoint>
 az ml online-endpoint create --name $ENDPOINT_NAME -f endpoints/online/amlarc/endpoint.yml

--- a/cli/deploy-safe-rollout-online-endpoints.sh
+++ b/cli/deploy-safe-rollout-online-endpoints.sh
@@ -6,7 +6,7 @@ export ENDPOINT_NAME="<YOUR_ENDPOINT_NAME>"
 # </set_endpoint_name>
 
 #  endpoint name
-export ENDPOINT_NAME=endpt-`echo $RANDOM`
+export ENDPOINT_NAME=endpt-sr-`echo $RANDOM`
 
 # <create_endpoint>
 az ml online-endpoint create --name $ENDPOINT_NAME -f endpoints/online/managed/sample/endpoint.yml

--- a/cli/deploy-tfserving.sh
+++ b/cli/deploy-tfserving.sh
@@ -42,7 +42,7 @@ docker stop tfserving-test
 export ENDPOINT_NAME="<YOUR_ENDPOINT_NAME>"
 # </set_endpoint_name>
 
-export ENDPOINT_NAME=endpt-`echo $RANDOM`
+export ENDPOINT_NAME=endpt-tfserving-`echo $RANDOM`
 
 # <create_endpoint>
 az ml online-endpoint create --name $ENDPOINT_NAME -f endpoints/online/custom-container/tfserving-endpoint.yml


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes
We seem to run out of endpoint quota. Assumption here is endpoints are got getting deleted in some samples. Earlier all endpoints were named "endpt-random number" , with this change, we will have prefix of the sample name. For e.g. for autoscale we will have "endpt-autoscale-random number"
fixes #

