### PR TITLE
Update SDK version, remove pandas max_colwidth option for AutoML model test notebooks and fix environment.

### DIFF
--- a/python-sdk/cleanup.py
+++ b/python-sdk/cleanup.py
@@ -8,7 +8,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--config", type=str, default="")
 args = parser.parse_args()
 
-#Authenticate to the workspace using the credentials cached by the CLI
+# Authenticate to the workspace using the credentials cached by the CLI
 cli_auth = AzureCliAuthentication()
 
 # get workspace

--- a/python-sdk/experimental/automl-model-testing/automl_env_linux.yml
+++ b/python-sdk/experimental/automl-model-testing/automl_env_linux.yml
@@ -1,31 +1,35 @@
 name: azure_automl
+channels:
+  - conda-forge
+  - pytorch
+  - main
 dependencies:
   # The python interpreter version.
-  # Currently Azure ML only supports 3.5.2 and later.
+  # Currently Azure ML only supports 3.6.0 and later.
 - pip==21.1.2
-- python>=3.5.2,<3.8
+- python>=3.6,<3.9
 - nb_conda
-- boto3==1.15.18
-- matplotlib==2.1.0
-- numpy==1.18.5
-- cython
-- urllib3<1.24
+- boto3==1.20.19
+- botocore<=1.23.19
+- matplotlib==3.3.4
+- numpy==1.19.5
+- cython==0.29.14
+- urllib3==1.26.7
 - scipy>=1.4.1,<=1.5.2
 - scikit-learn==0.22.1
-- pandas==0.25.1
-- py-xgboost<=0.90
-- conda-forge::fbprophet==0.5
-- holidays==0.9.11
+- py-xgboost<=1.3.3
+- holidays==0.10.3
+- conda-forge::fbprophet==0.7.1
 - pytorch::pytorch=1.4.0
 - cudatoolkit=10.1.243
-- tornado==6.1.0
 
 - pip:
   # Required packages for AzureML execution, history, and data preparation.
-  - azureml-sdk
-  - azureml-widgets
+  - azureml-widgets~=1.39.0
   - pytorch-transformers==1.0.0
-  - spacy==2.1.8
+  - spacy==2.2.4
+  - pystan==2.19.1.1
   - https://aka.ms/automl-resources/packages/en_core_web_sm-2.1.0.tar.gz
-  - -r https://automlresources-prod.azureedge.net/validated-requirements/1.35.0/validated_linux_requirements.txt [--no-deps]
+  - -r https://automlsdkdataresources.blob.core.windows.net/validated-requirements/1.39.0/validated_linux_requirements.txt [--no-deps]
+  - azure-cli
   - arch==4.14

--- a/python-sdk/experimental/automl-model-testing/classification/classification-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/classification/classification-TSI.ipynb
@@ -100,7 +100,7 @@
    },
    "outputs": [],
    "source": [
-    "print(\"This notebook was created using version 1.36.0 of the Azure ML SDK\")\n",
+    "print(\"This notebook was created using version 1.40.0 of the Azure ML SDK\")\n",
     "print(\"You are currently using version\", azureml.core.VERSION, \"of the Azure ML SDK\")"
    ]
   },
@@ -128,7 +128,7 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Experiment Name\"] = experiment.name\n",
-    "pd.set_option(\"display.max_colwidth\", -1)\n",
+    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/classification/classification-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/classification/classification-TSI.ipynb
@@ -128,7 +128,6 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Experiment Name\"] = experiment.name\n",
-    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/classification/classification-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/classification/classification-TSI.ipynb
@@ -128,6 +128,7 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Experiment Name\"] = experiment.name\n",
+    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/forecasting/forecasting-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/forecasting/forecasting-TSI.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"This notebook was created using version 1.36.0 of the Azure ML SDK\")\n",
+    "print(\"This notebook was created using version 1.40.0 of the Azure ML SDK\")\n",
     "print(\"You are currently using version\", azureml.core.VERSION, \"of the Azure ML SDK\")"
    ]
   },
@@ -112,7 +112,7 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Run History Name\"] = experiment_name\n",
-    "pd.set_option(\"display.max_colwidth\", -1)\n",
+    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/forecasting/forecasting-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/forecasting/forecasting-TSI.ipynb
@@ -112,6 +112,7 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Run History Name\"] = experiment_name\n",
+    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/forecasting/forecasting-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/forecasting/forecasting-TSI.ipynb
@@ -112,7 +112,6 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Run History Name\"] = experiment_name\n",
-    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/regression/regression-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/regression/regression-TSI.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"This notebook was created using version 1.36.0 of the Azure ML SDK\")\n",
+    "print(\"This notebook was created using version 1.40.0 of the Azure ML SDK\")\n",
     "print(\"You are currently using version\", azureml.core.VERSION, \"of the Azure ML SDK\")"
    ]
   },
@@ -112,7 +112,7 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Run History Name\"] = experiment_name\n",
-    "pd.set_option(\"display.max_colwidth\", -1)\n",
+    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/regression/regression-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/regression/regression-TSI.ipynb
@@ -112,6 +112,7 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Run History Name\"] = experiment_name\n",
+    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]

--- a/python-sdk/experimental/automl-model-testing/regression/regression-TSI.ipynb
+++ b/python-sdk/experimental/automl-model-testing/regression/regression-TSI.ipynb
@@ -112,7 +112,6 @@
     "output[\"Resource Group\"] = ws.resource_group\n",
     "output[\"Location\"] = ws.location\n",
     "output[\"Run History Name\"] = experiment_name\n",
-    "pd.set_option(\"display.max_colwidth\", None)\n",
     "outputDf = pd.DataFrame(data=output, index=[\"\"])\n",
     "outputDf.T"
    ]


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- Updated the SDK version of the notebooks to 1.40
- Remove a pandas warning when setting the max_colwidth parameter. All 3 notebooks were run using 1.40 and the warning no longer appeared. This is being removed since it does not provide any significant value to the notebook output and causes warnings in the output cells. These warnings are unnecessary and are causing the pipelines gates to fail.
- Fix the environment which is used for the check-in workflows and has been failing for the past few weeks.

fixes #

