### PR TITLE
Removing mlflow as explicit dependency 

### DIFF
--- a/cli/jobs/single-step/scikit-learn/iris-notebook/docker-context/requirements.txt
+++ b/cli/jobs/single-step/scikit-learn/iris-notebook/docker-context/requirements.txt
@@ -5,7 +5,6 @@ pandas==1.3.0
 scikit-learn==0.24.2
 
 # tracking
-mlflow==1.20.2
 azureml-mlflow==1.34.0
 
 # visualization


### PR DESCRIPTION
Removing mlflow as explicit dependency  since pinning it conflicts with mlflow-skinny brought in by azureml-mlflow

# PR into Azure/azureml-examples

## Checklist

I have:

- [X] read and followed the contributing guidelines

## Changes

-

fixes #

