### PR TITLE
remove unnecessary package installs in managed online endpoint scripts

### DIFF
--- a/.github/workflows/cli-scripts-deploy-local-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-local-endpoint.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-local-endpoint.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-managed-online-endpoint-access-resource-sai.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-managed-online-endpoint-access-resource-uai.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-managed-online-endpoint-mlflow.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-managed-online-endpoint.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-moe-autoscale.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-r.yml
+++ b/.github/workflows/cli-scripts-deploy-r.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-r.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-rest.yml
+++ b/.github/workflows/cli-scripts-deploy-rest.yml
@@ -25,7 +25,7 @@ jobs:
       working-directory: cli
       continue-on-error: true
     - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
+      run: sudo apt-get install jq -y
     - name: test script script
       run: set -e; bash -x deploy-rest.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-safe-rollout-online-endpoints.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-tfserving.yml
+++ b/.github/workflows/cli-scripts-deploy-tfserving.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-tfserving.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-torchserve.yml
+++ b/.github/workflows/cli-scripts-deploy-torchserve.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-torchserve.sh
       working-directory: cli

--- a/.github/workflows/cli-scripts-deploy-triton-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-triton-managed-online-endpoint.yml
@@ -24,8 +24,6 @@ jobs:
       run: bash setup.sh
       working-directory: cli
       continue-on-error: true
-    - name: scripts installs
-      run: sudo apt-get upgrade -y && sudo apt-get install uuid-runtime jq -y
     - name: test script script
       run: set -e; bash -x deploy-triton-managed-online-endpoint.sh
       working-directory: cli


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

All of the online deployment scripts are failing because of apt-get upgrade is failing to fetch packages. However these are not done for any other scripts (e.g.training scripts) and not needed here. Sample error: https://github.com/Azure/azureml-examples/runs/6379836810?check_suite_focus=true#step:5:41

- all scripts (except the below one): removed the step that upgrades and installs new packages
- deploy-rest script: This script needs only the jq package - remove other package installs

Known issue: UAI script seems to be [failing ](https://github.com/Azure/azureml-examples/runs/6380697937?check_suite_focus=true#step:5:258)in main even before this fix. Requesting @petrodeg to look in to this outside of this PR