### PR TITLE
Change Endpoint scoring files to point to model as a directory 

### DIFF
--- a/.github/workflows/cli-scripts-deploy-local-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-local-endpoint.yml
@@ -10,6 +10,8 @@ on:
       - cli/deploy-local-endpoint.sh
       - .github/workflows/cli-scripts-deploy-local-endpoint.yml
       - cli/setup.sh
+      - cli/endpoints/online/managed
+      - cli/endpoints/online/model-1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-local-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-local-endpoint.yml
@@ -10,7 +10,7 @@ on:
       - cli/deploy-local-endpoint.sh
       - .github/workflows/cli-scripts-deploy-local-endpoint.yml
       - cli/setup.sh
-      - cli/endpoints/online/managed
+      - cli/endpoints/online/managed/sample
       - cli/endpoints/online/model-1
 jobs:
   build:

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
@@ -10,7 +10,7 @@ on:
       - cli/deploy-managed-online-endpoint-access-resource-sai.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
       - cli/setup.sh
-      - cli/endpoints/online/managed/managed-identity
+      - cli/endpoints/online/managed/managed-identities
       - cli/endpoints/online/model-1
 jobs:
   build:

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
@@ -10,6 +10,8 @@ on:
       - cli/deploy-managed-online-endpoint-access-resource-sai.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
       - cli/setup.sh
+      - cli/endpoints/online/managed/managed-identity
+      - cli/endpoints/online/model-1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
@@ -10,7 +10,7 @@ on:
       - cli/deploy-managed-online-endpoint-access-resource-uai.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
       - cli/setup.sh
-      - cli/endpoints/online/managed/managed-identity
+      - cli/endpoints/online/managed/managed-identities
       - cli/endpoints/online/model-1
 jobs:
   build:

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
@@ -10,6 +10,8 @@ on:
       - cli/deploy-managed-online-endpoint-access-resource-uai.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
       - cli/setup.sh
+      - cli/endpoints/online/managed/managed-identity
+      - cli/endpoints/online/model-1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
@@ -10,6 +10,8 @@ on:
       - cli/deploy-managed-online-endpoint-mlflow.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
       - cli/setup.sh
+      - cli/endpoints/online/managed
+      - cli/endpoints/online/mlflow
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
@@ -10,7 +10,6 @@ on:
       - cli/deploy-managed-online-endpoint-mlflow.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint-mlflow.yml
       - cli/setup.sh
-      - cli/endpoints/online/managed
       - cli/endpoints/online/mlflow
 jobs:
   build:

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
@@ -10,7 +10,7 @@ on:
       - cli/deploy-managed-online-endpoint.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
       - cli/setup.sh
-      - cli/endpoints/online/managed
+      - cli/endpoints/online/managed/sample
       - cli/endpoints/online/model-1
 jobs:
   build:

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
@@ -10,6 +10,8 @@ on:
       - cli/deploy-managed-online-endpoint.sh
       - .github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
       - cli/setup.sh
+      - cli/endpoints/online/managed
+      - cli/endpoints/online/model-1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
@@ -10,6 +10,8 @@ on:
       - cli/deploy-moe-autoscale.sh
       - .github/workflows/cli-scripts-deploy-moe-autoscale.yml
       - cli/setup.sh
+      - cli/endpoints/online/managed
+      - cli/endpoints/online/model-1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
@@ -10,7 +10,7 @@ on:
       - cli/deploy-moe-autoscale.sh
       - .github/workflows/cli-scripts-deploy-moe-autoscale.yml
       - cli/setup.sh
-      - cli/endpoints/online/managed
+      - cli/endpoints/online/managed/sample
       - cli/endpoints/online/model-1
 jobs:
   build:

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
       - cli/setup.sh
       - .github/kubernetes-compute/tool.sh
+      - cli/endpoints/online/kubernetes
+      - cli/endpoints/online/model-1
+      - cli/endpoints/online/model-2
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
@@ -10,6 +10,9 @@ on:
       - cli/deploy-safe-rollout-online-endpoints.sh
       - .github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
       - cli/setup.sh
+      - cli/endpoints/online/managed
+      - cli/endpoints/online/model-1
+      - cli/endpoints/online/model-2
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
@@ -10,7 +10,7 @@ on:
       - cli/deploy-safe-rollout-online-endpoints.sh
       - .github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
       - cli/setup.sh
-      - cli/endpoints/online/managed
+      - cli/endpoints/online/managed/sample
       - cli/endpoints/online/model-1
       - cli/endpoints/online/model-2
 jobs:

--- a/cli/endpoints/online/kubernetes/kubernetes-blue-deployment.yml
+++ b/cli/endpoints/online/kubernetes/kubernetes-blue-deployment.yml
@@ -2,7 +2,7 @@ name: blue
 type: kubernetes
 endpoint_name: my-endpoint
 model:
-  path: ../model-1/model/sklearn_regression_model.pkl
+  path: ../model-1/model/
 code_configuration:
   code: ../model-1/onlinescoring/
   scoring_script: score.py

--- a/cli/endpoints/online/kubernetes/kubernetes-green-deployment.yml
+++ b/cli/endpoints/online/kubernetes/kubernetes-green-deployment.yml
@@ -3,7 +3,7 @@ type: kubernetes
 endpoint_name: my-endpoint
 app_insights_enabled: true
 model:
-  path: ../model-2/model/sklearn_regression_model.pkl
+  path: ../model-2/model/
 code_configuration:
   code: ../model-2/onlinescoring/
   scoring_script: score.py

--- a/cli/endpoints/online/managed/managed-identities/2-sai-deployment.yml
+++ b/cli/endpoints/online/managed/managed-identities/2-sai-deployment.yml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineDeployment.schema.json
 name: blue
 model:
-  path: ../../model-1/model/sklearn_regression_model.pkl
+  path: ../../model-1/model/
 code_configuration:
   code: ../../model-1/onlinescoring/
   scoring_script: score_managedidentity.py

--- a/cli/endpoints/online/managed/managed-identities/2-uai-deployment.yml
+++ b/cli/endpoints/online/managed/managed-identities/2-uai-deployment.yml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineDeployment.schema.json
 model:
-  path: ../../model-1/model/sklearn_regression_model.pkl
+  path: ../../model-1/model/
 code_configuration:
   code: ../../model-1/onlinescoring/
   scoring_script: score_managedidentity.py

--- a/cli/endpoints/online/managed/sample/blue-deployment.yml
+++ b/cli/endpoints/online/managed/sample/blue-deployment.yml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineDeployment.sch
 name: blue
 endpoint_name: my-endpoint
 model:
-  path: ../../model-1/model/sklearn_regression_model.pkl
+  path: ../../model-1/model/
 code_configuration:
   code: ../../model-1/onlinescoring/
   scoring_script: score.py

--- a/cli/endpoints/online/managed/sample/green-deployment.yml
+++ b/cli/endpoints/online/managed/sample/green-deployment.yml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineDeployment.sch
 name: green
 endpoint_name: my-endpoint
 model:
-  path: ../../model-2/model/sklearn_regression_model.pkl
+  path: ../../model-2/model/
 code_configuration:
   code: ../../model-2/onlinescoring/
   scoring_script: score.py

--- a/cli/endpoints/online/model-1/onlinescoring/score.py
+++ b/cli/endpoints/online/model-1/onlinescoring/score.py
@@ -13,8 +13,9 @@ def init():
     global model
     # AZUREML_MODEL_DIR is an environment variable created during deployment.
     # It is the path to the model folder (./azureml-models/$MODEL_NAME/$VERSION)
+    # Please provide your model's folder name if there is one
     model_path = os.path.join(
-        os.getenv("AZUREML_MODEL_DIR"), "sklearn_regression_model.pkl"
+        os.getenv("AZUREML_MODEL_DIR"), "models/sklearn_regression_model.pkl"
     )
     # deserialize the model file back into a sklearn model
     model = joblib.load(model_path)

--- a/cli/endpoints/online/model-1/onlinescoring/score.py
+++ b/cli/endpoints/online/model-1/onlinescoring/score.py
@@ -15,7 +15,7 @@ def init():
     # It is the path to the model folder (./azureml-models/$MODEL_NAME/$VERSION)
     # Please provide your model's folder name if there is one
     model_path = os.path.join(
-        os.getenv("AZUREML_MODEL_DIR"), "models/sklearn_regression_model.pkl"
+        os.getenv("AZUREML_MODEL_DIR"), "model/sklearn_regression_model.pkl"
     )
     # deserialize the model file back into a sklearn model
     model = joblib.load(model_path)

--- a/cli/endpoints/online/model-1/onlinescoring/score_managedidentity.py
+++ b/cli/endpoints/online/model-1/onlinescoring/score_managedidentity.py
@@ -58,7 +58,7 @@ def init():
     # For multiple models, it points to the folder containing all deployed models (./azureml-models)
     # Please provide your model's folder name if there is one
     model_path = os.path.join(
-        os.getenv("AZUREML_MODEL_DIR"), "models/sklearn_regression_model.pkl"
+        os.getenv("AZUREML_MODEL_DIR"), "model/sklearn_regression_model.pkl"
     )
     # deserialize the model file back into a sklearn model
     model = joblib.load(model_path)

--- a/cli/endpoints/online/model-1/onlinescoring/score_managedidentity.py
+++ b/cli/endpoints/online/model-1/onlinescoring/score_managedidentity.py
@@ -56,8 +56,9 @@ def init():
     # AZUREML_MODEL_DIR is an environment variable created during deployment.
     # It is the path to the model folder (./azureml-models/$MODEL_NAME/$VERSION)
     # For multiple models, it points to the folder containing all deployed models (./azureml-models)
+    # Please provide your model's folder name if there is one
     model_path = os.path.join(
-        os.getenv("AZUREML_MODEL_DIR"), "sklearn_regression_model.pkl"
+        os.getenv("AZUREML_MODEL_DIR"), "models/sklearn_regression_model.pkl"
     )
     # deserialize the model file back into a sklearn model
     model = joblib.load(model_path)

--- a/cli/endpoints/online/model-2/onlinescoring/score.py
+++ b/cli/endpoints/online/model-2/onlinescoring/score.py
@@ -13,8 +13,9 @@ def init():
     global model
     # AZUREML_MODEL_DIR is an environment variable created during deployment.
     # It is the path to the model folder (./azureml-models/$MODEL_NAME/$VERSION)
+    # Please provide your model's folder name if there is one
     model_path = os.path.join(
-        os.getenv("AZUREML_MODEL_DIR"), "sklearn_regression_model.pkl"
+        os.getenv("AZUREML_MODEL_DIR"), "models/sklearn_regression_model.pkl"
     )
     # deserialize the model file back into a sklearn model
     model = joblib.load(model_path)

--- a/cli/endpoints/online/model-2/onlinescoring/score.py
+++ b/cli/endpoints/online/model-2/onlinescoring/score.py
@@ -15,7 +15,7 @@ def init():
     # It is the path to the model folder (./azureml-models/$MODEL_NAME/$VERSION)
     # Please provide your model's folder name if there is one
     model_path = os.path.join(
-        os.getenv("AZUREML_MODEL_DIR"), "models/sklearn_regression_model.pkl"
+        os.getenv("AZUREML_MODEL_DIR"), "model/sklearn_regression_model.pkl"
     )
     # deserialize the model file back into a sklearn model
     model = joblib.load(model_path)


### PR DESCRIPTION
Swaps all of the endpoint samples to use a directory-based model instead of a file-based model to align with the run_spec for custom_model being a uri_folder.

# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

-

fixes #

