### PR TITLE
Specify protobuf version to fix import mlflow error

### DIFF
--- a/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb
+++ b/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb
@@ -360,7 +360,8 @@
     "    - inference-schema[numpy-support]==1.3.0\n",
     "    - xlrd==2.0.1\n",
     "    - mlflow== 1.26.0\n",
-    "    - azureml-mlflow==1.41.0"
+    "    - azureml-mlflow==1.41.0\n",
+    "    - protobuf==3.20.1"
    ]
   },
   {


### PR DESCRIPTION
The current tutorial will fail at the data_prep component due to the import mlflow issue, see https://github.com/mlflow/mlflow/issues/5949.
Requiring protobuf version at 3.20.1 as proposed in this PR will fix the issue.

# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- Add `protobuf==3.20.1` in `conda.yml` to resolve conflict with `mlflow`. 

fixes #

