### PR TITLE
Add "requests" to the list of packages in deploy-triton-managed-online-endpoint.sh

### DIFF
--- a/cli/deploy-triton-managed-online-endpoint.sh
+++ b/cli/deploy-triton-managed-online-endpoint.sh
@@ -7,6 +7,7 @@ pip install numpy
 pip install tritonclient[http]
 pip install pillow
 pip install gevent
+pip install requests
 # </installing-requirements>
 
 # <set_endpoint_name>


### PR DESCRIPTION
triton_densenet_scoring.py depends on "requests" package, which doesn't seem to be installed as a dependency of the currently listed packages.
Hence, adding it here to make the experience smoother.

