### PR TITLE
Deepspeed megatron

### DIFF
--- a/python-sdk/workflows/train/deepspeed/megatron-deepspeed/README.md
+++ b/python-sdk/workflows/train/deepspeed/megatron-deepspeed/README.md
@@ -1,0 +1,12 @@
+# Megatron-DeepSpeed
+
+Megatron-DeepSpeed is a complex example and is maintained in a seperate [GitHub repository](https://github.com/microsoft/Megatron-DeepSpeed). DeepSpeed's version is a fork of NVIDIA's Megatron-LM that adds additional support for several features such as MoE model training, Curriculum Learning, 3D Parallelism, and easy-to-use examples for training on Azure.
+
+
+## Megatron-DeepSpeed on AzureML
+
+Please refer to the following link for running this example on AzureML:
+
+https://github.com/microsoft/Megatron-DeepSpeed#run-on-azure-and-azureml
+
+The AzureML job.py (submission script) is available inside the ```azureml/```[```examples```](https://github.com/microsoft/Megatron-DeepSpeed/tree/main/examples).

--- a/python-sdk/workflows/train/deepspeed/megatron-deepspeed/README.md
+++ b/python-sdk/workflows/train/deepspeed/megatron-deepspeed/README.md
@@ -1,6 +1,6 @@
 # Megatron-DeepSpeed
 
-Megatron-DeepSpeed is a complex example and is maintained in a seperate [GitHub repository](https://github.com/microsoft/Megatron-DeepSpeed). DeepSpeed's version is a fork of NVIDIA's Megatron-LM that adds additional support for several features such as MoE model training, Curriculum Learning, 3D Parallelism, and easy-to-use examples for training on Azure.
+Megatron-DeepSpeed is a complex example and is maintained in a seperate [GitHub repository](https://github.com/microsoft/Megatron-DeepSpeed). It is a fork of NVIDIA's Megatron-LM that adds additional support for several features such as MoE model training, Curriculum Learning, 3D Parallelism, and easy-to-use examples for training on Azure.
 
 
 ## Megatron-DeepSpeed on AzureML
@@ -9,4 +9,4 @@ Please refer to the following link for running this example on AzureML:
 
 https://github.com/microsoft/Megatron-DeepSpeed#run-on-azure-and-azureml
 
-The AzureML job.py (submission script) is available inside the ```azureml/```[```examples```](https://github.com/microsoft/Megatron-DeepSpeed/tree/main/examples).
+The AzureML job submission script (the training recipe) and other configuration files are available inside the [```examples/azureml```](https://github.com/microsoft/Megatron-DeepSpeed/tree/main/examples).


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- Add a README file that links to a complex training example that is maintained in its own GH repo. 
- Connects @msp8955 PR (https://github.com/microsoft/Megatron-DeepSpeed/pull/66) to support Megatron-Deepspeed on AzureML

cc @msp8955 -- please see this PR and assign the right AML folks to get it merged.
