### PR TITLE
Changing command to downgrade python as current command still installing wrong version of pip

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -18,7 +18,7 @@ jobs:
       with: 
         python-version: "3.8"
     - name: downgrade pip
-      run: pip install pip==21.1.1
+      run: python -m pip install --upgrade pip==21.1.1
     - name: pip install
       run: pip install -r requirements.txt
       working-directory: python-sdk


### PR DESCRIPTION
Changing command to downgrade pip as current command still installing the latest version.

# PR into Azure/azureml-examples

## Checklist

I have:

- [ ] read and followed the contributing guidelines

## Changes

-

fixes #

