### PR TITLE
Fixed display of prediction in automl-image-classification-multilabel…

### DIFF
--- a/sdk/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items-mlflow.ipynb
+++ b/sdk/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items-mlflow.ipynb
@@ -1077,7 +1077,8 @@
     "fig, ax = plt.subplots(1, figsize=(15, 15))\n",
     "# Display the image\n",
     "ax.imshow(img_np)\n",
-    "prediction = json.loads(resp)\n",
+    "prediction_list = json.loads(resp)\n",
+    "prediction = prediction_list[0]\n",
     "score_threshold = 0.5\n",
     "\n",
     "label_offset_x = 30\n",
@@ -1160,7 +1161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.12"
   },
   "microsoft": {
    "host": {


### PR DESCRIPTION
…-task-fridge-items-mlflow

# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- Fixed display of prediction in automl-image-classification-multilabel-task-fridge-items-mlflow
- The value returned from the service is a list of predictions.
- In this case only one image was passed and so only one prediction is used

fixes #

