### PR TITLE
Send IcM on notebook validation failure

### DIFF
--- a/.github/actions/generate-icm/.gitignore
+++ b/.github/actions/generate-icm/.gitignore
@@ -1,0 +1,165 @@
+####
+# Pythno
+####
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/.github/actions/generate-icm/action.yaml
+++ b/.github/actions/generate-icm/action.yaml
@@ -1,0 +1,43 @@
+name: Generate IcM
+description: |
+    A github action that facilitates IcM generation using the the IcM
+    connector webservice.
+inputs:
+    connector_id:
+        description: "IcM Connector ID"
+        required: true
+    host:
+        description: "Hostname for the IcM webservice"
+        required: true
+    certificate:
+        description: A certificate
+        required: true
+    private_key: 
+        description: The unencrypted private-key associated with the certificate
+        required: true
+    args:
+        description: |
+            A yaml encoded string that describes the arguments for 
+            AddOrUpdateIncident2. See IcM documentation on Connector API
+        required: true
+
+runs:
+    using: "composite"
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: "pip"
+      - name: Install Dependencies
+        run: pip install -r "${{ github.action_path }}/requirements.txt"
+        shell: bash
+      - name: Send IcM
+        run: python "${{ github.action_path }}/main.py" 
+        shell: bash
+        env:
+          INPUT_HOST: ${{ inputs.host }}
+          INPUT_CONNECTOR_ID: ${{ inputs.connector_id }}
+          INPUT_CERTIFICATE: ${{ inputs.certificate }}
+          INPUT_PRIVATE_KEY: ${{ inputs.private_key }}
+          INPUT_ARGS: ${{ inputs.args }}

--- a/.github/actions/generate-icm/main.py
+++ b/.github/actions/generate-icm/main.py
@@ -1,0 +1,326 @@
+import argparse
+import contextlib
+from datetime import datetime
+import os
+from pathlib import Path
+import sys
+from tempfile import NamedTemporaryFile
+from typing import Any, Literal, Optional, TypeAlias, TypeVar, overload
+import requests
+import yaml
+from pydantic import BaseModel
+from xml.etree import ElementTree
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+RoutingOptions: TypeAlias = Literal["None", "SkipTransferOnUpdate"]
+
+
+class SOAPFault(Exception):
+    """SOAP 1.2 Fault"""
+    def __init__(
+        self,
+        *,
+        code: str,
+        reason: str,
+        role: Optional[str] = None,
+        node: Optional[str],
+        detail: Optional[str] = None
+    ):
+        self.code = code
+        self.reason = reason
+        self.role = role
+        self.node = node
+        self.detail = detail
+
+
+class AuthCert(BaseModel):
+    cert: Path
+    private_key: Path
+
+
+class AddOrUpdateIncident2Args(BaseModel):
+    routingOptions: RoutingOptions = "None"
+    incident: dict
+    connectorId: str
+
+
+class AddOrUpdateIncident2Result(BaseModel):
+    IncidentId: int
+    Status: Literal["Invalid", "AddedNew", "UpdatedExisting",
+                    "DidNotChangeExisting", "AlertSourceUpdatesPending",
+                    "UpdateToHoldingNotAllowed", "Discarded"]
+
+
+class ActionArgs(BaseModel):
+    host: str
+    auth: AuthCert
+    args: AddOrUpdateIncident2Args
+
+
+def sorted_dict(val: T) -> T:
+    """Returns a copy of dict `val` where key-values are inserted in 
+    alphabetical order. If `val` is not a dict, it's returned unchanged
+
+    Args:
+        val (T): Any value
+
+    Returns:
+        T: Either the same value passed in if not a dict, or a copy 
+           with keys inserted in alphabetical order
+    """
+    if not isinstance(val, dict):
+        return val
+
+    return {
+        k: sorted_dict(v)
+        for k, v in sorted(val.items(), key=lambda kv: kv[0])
+    }
+
+
+@overload
+def mergeLeft(left: T, right: U) -> U:
+    ...
+
+
+def mergeLeft(left: dict, right: dict) -> dict:
+    if not (isinstance(left, dict) and isinstance(right, dict)):
+        return right
+    for k, v in right.items():
+        left[k] = mergeLeft(left.get(k, None), v)
+
+    return left
+
+
+def string_to_tempfile(s: str):
+    """Writes a utf-8 encoded string into a temporary file
+
+    Args:
+        s (str): Base64 encoded string
+
+    Returns:
+        NamedTemporaryFile: Temp File, must be closed by caller
+    """
+    tmp = NamedTemporaryFile()
+    tmp.write(bytes(s, encoding="utf-8"))
+    tmp.seek(0)
+    return tmp
+
+
+def toXML(obj: dict, xsi_namespace="i") -> str:
+    """Serializes a dict into an XML string
+
+    Args:
+        obj (dict): dict to serialize
+        xsi_namespace (str, optional): Prefix for the Schema Instance Namespace. Defaults to "i".
+
+    Returns:
+        str: xml string representing the dict
+    """
+    ATTRIBUTESKEY = "$attributes"
+    NAMESPACEKEY = "$namespace"
+
+    def tag(
+        name: str,
+        value: str,
+        *,
+        attributes: dict = {},
+        namespace: str = None
+    ) -> str:
+        """Surrounds a string in xml tags
+
+        Args:
+            name (str): Name of tag
+            value (str): Value of tag
+            attributes (dict, optional): Dict of attributes for xml element. Defaults to {}.
+            namespace (str, optional): Namespace prefix for the tag. Defaults to None.
+
+        Returns:
+            str: xml string
+        """
+        attributes_str = ' '.join(f'{k}="{v}"' for k, v in attributes.items())
+        ns = f"{namespace}:" if namespace else ""
+        if attributes_str:
+            attributes_str = ' ' + attributes_str
+        if value:
+            return f'<{ns}{name}{attributes_str}>{value}</{ns}{name}>'
+        return f'<{ns}{name}{attributes_str} />'
+
+    def serialize_dict(val: dict, namespace: str = None) -> str:
+        ns = val.pop(NAMESPACEKEY, namespace)
+        return ''.join(serialize(k, v, ns) for k, v in val.items())
+
+    def serialize(name: str, val: Any, namespace: str = None) -> str:
+        """Serializes a key value pair into an XML element
+
+        Args:
+            name (str): Tag name for element
+            val (Any): Value to serialize
+            namespace (str, optional): Namespace to prepend to child tags
+            of value. Defaults to None.
+
+        Returns:
+            str: XML string
+        """
+        t = lambda v, a={}: tag(name, v, attributes=a, namespace=namespace)
+        if isinstance(val, dict):
+            attrs = val.pop(ATTRIBUTESKEY, {})
+            return t(serialize_dict(val, namespace), attrs)
+        if isinstance(val, list):
+            return t(
+                ''.join(serialize_dict(v, namespace=namespace) for v in val)
+            )
+        elif isinstance(val, bool):
+            return t(str(val).lower())
+        elif val is None:
+            return t(None, {f"{xsi_namespace}:nil": "true"})
+        else:
+            return t(str(val))
+
+    return serialize_dict(obj)
+
+
+@contextlib.contextmanager
+def parseArgs():
+    """Parses the github action arguments. Must be invoke with `with` statement
+
+    Yields:
+        _type_: ActionArgs
+    """
+    def getInput(name: str, *, required=False):
+        val = os.environ.get(f'INPUT_{name.replace(" ", "_").upper()}', "")
+        if not val and required:
+            raise ValueError(f"Missing required parameter: {name}")
+        return val
+
+    certificate = getInput("certificate", required=True)
+    private_key = getInput("private_key", required=True)
+    connectorId = getInput("connector_id", required=True)
+    host = getInput("host", required=True)
+    body = yaml.load(getInput("args", required=True), yaml.Loader)
+
+    with string_to_tempfile(certificate) as cert_file, string_to_tempfile(
+        private_key
+    ) as key_file:
+        yield ActionArgs(
+            host=host,
+            auth=AuthCert(
+                cert=Path(cert_file.name), private_key=Path(key_file.name)
+            ),
+            args=AddOrUpdateIncident2Args(**body, connectorId=connectorId)
+        )
+
+
+def add_or_update_incident_2(
+    host: str, auth: AuthCert, args: AddOrUpdateIncident2Args
+):
+    now = datetime.utcnow().isoformat()
+    soap_ns = "http://www.w3.org/2003/05/soap-envelope"
+    icm_ns = "http://schemas.datacontract.org/2004/07/Microsoft.AzureAd.Icm.Types"
+    baseIncident = {
+        "OccurringLocation": {},
+        "RaisingLocation": {},
+        "Source":
+            {
+                "CreatedBy": "Monitor",
+                "Origin": "Monitor",
+                "SourceId": args.connectorId,
+                "CreateDate": now,
+                "ModifiedDate": now,
+            },
+        "Severity": 4,
+    }
+    incident = sorted_dict(
+        {
+            "$attributes":
+                {
+                    "xmlns:b": icm_ns,
+                    "xmlns:i": "http://www.w3.org/2001/XMLSchema-instance"
+                },
+            "$namespace": "b",
+            **mergeLeft(baseIncident, args.incident)
+        }
+    )
+    soap_message = {
+        "s:Envelope":
+            {
+                "$attributes":
+                    {
+                        "xmlns:s": soap_ns,
+                        "xmlns:a": "http://www.w3.org/2005/08/addressing",
+                    },
+                "s:Header":
+                    {
+                        "a:Action":
+                            "http://tempuri.org/IConnectorIncidentManager/AddOrUpdateIncident2",
+                        "a:To":
+                            f"https://{host}/Connector3/ConnectorIncidentManager.svc"
+                    },
+                "s:Body":
+                    {
+                        # Key order is significant, must be in alphabetical
+                        # order
+                        "AddOrUpdateIncident2":
+                            {
+                                "connectorId": args.connectorId,
+                                "incident": incident,
+                                "routingOptions": args.routingOptions,
+                                "$attributes": {
+                                    "xmlns": "http://tempuri.org/"
+                                },
+                            }
+                    }
+            }
+    }
+
+    response = requests.post(
+        f"https://{host}/Connector3/ConnectorIncidentManager.svc",
+        cert=(auth.cert, auth.private_key),
+        headers={'Content-Type': 'application/soap+xml; charset=utf-8'},
+        data='<?xml version="1.0" encoding="UTF-8"?>\n' + toXML(soap_message)
+    )
+
+    xml_result = ElementTree.fromstring(response.text)
+    fault = xml_result.find(f".//{{{soap_ns}}}Fault")
+
+    if fault:
+
+        def innerXML(element: Optional[ElementTree.Element]) -> Optional[str]:
+            return element and (
+                element.text or
+                ''.join(ElementTree.tostring(e, 'unicode') for e in element)
+            )
+
+        raise SOAPFault(
+            code=innerXML(fault.find(f".//{{{soap_ns}}}Code")),
+            reason=innerXML(fault.find(f".//{{{soap_ns}}}Reason")),
+            role=innerXML(fault.find(f".//{{{soap_ns}}}Role")),
+            detail=innerXML(fault.find(f".//{{{soap_ns}}}Detail")),
+            node=innerXML(fault.find(f".//{{{soap_ns}}}Node")),
+        )
+
+    return AddOrUpdateIncident2Result(
+        IncidentId=int(xml_result.findtext(f'.//{{{icm_ns}}}IncidentId')),
+        Status=xml_result.findtext(f'.//{{{icm_ns}}}Status')
+    )
+
+
+def main():
+    # Utility functions to report status to Github Action Runner
+    core = {
+        "debug": lambda s: print(f"::debug::{s}"),
+        "error": lambda s: print(f"::error::{s}")
+    }
+
+    with parseArgs() as args:
+        try:
+            add_or_update_incident_2(**vars(args))
+        except SOAPFault as e:
+            core["debug"](e.detail)
+            core["error"](e.reason)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/generate-icm/requirements.txt
+++ b/.github/actions/generate-icm/requirements.txt
@@ -1,0 +1,3 @@
+pydantic
+requests
+pyyaml

--- a/.github/workflows/sdk-assets-component-component.yml
+++ b/.github/workflows/sdk-assets-component-component.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: component
         path: sdk/python/assets/component
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/component/component.ipynb'"
+                Summary: |
+                    Notebook 'assets/component/component.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "assets/component/component.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-component-component.yml
+++ b/.github/workflows/sdk-assets-component-component.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-assets-data-data.yml
+++ b/.github/workflows/sdk-assets-data-data.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-assets-data-data.yml
+++ b/.github/workflows/sdk-assets-data-data.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: data
         path: sdk/python/assets/data
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/data/data.ipynb'"
+                Summary: |
+                    Notebook 'assets/data/data.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "assets/data/data.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-data-working_with_mltable.yml
+++ b/.github/workflows/sdk-assets-data-working_with_mltable.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-assets-data-working_with_mltable.yml
+++ b/.github/workflows/sdk-assets-data-working_with_mltable.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: working_with_mltable
         path: sdk/python/assets/data
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/data/working_with_mltable.ipynb'"
+                Summary: |
+                    Notebook 'assets/data/working_with_mltable.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "assets/data/working_with_mltable.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-environment-environment.yml
+++ b/.github/workflows/sdk-assets-environment-environment.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: environment
         path: sdk/python/assets/environment
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/environment/environment.ipynb'"
+                Summary: |
+                    Notebook 'assets/environment/environment.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "assets/environment/environment.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-environment-environment.yml
+++ b/.github/workflows/sdk-assets-environment-environment.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-assets-model-model.yml
+++ b/.github/workflows/sdk-assets-model-model.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-assets-model-model.yml
+++ b/.github/workflows/sdk-assets-model-model.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: model
         path: sdk/python/assets/model
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/model/model.ipynb'"
+                Summary: |
+                    Notebook 'assets/model/model.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "assets/model/model.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-batch-mnist-nonmlflow.yml
+++ b/.github/workflows/sdk-endpoints-batch-mnist-nonmlflow.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-endpoints-batch-mnist-nonmlflow.yml
+++ b/.github/workflows/sdk-endpoints-batch-mnist-nonmlflow.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: mnist-nonmlflow
         path: sdk/python/endpoints/batch
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/batch/mnist-nonmlflow.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/batch/mnist-nonmlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/batch/mnist-nonmlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: online-endpoints-custom-container
         path: sdk/python/endpoints/online/custom-container
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/custom-container/online-endpoints-custom-container.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/online/custom-container/online-endpoints-custom-container.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/online/custom-container/online-endpoints-custom-container.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: online-endpoints-triton-cc
         path: sdk/python/endpoints/online/custom-container/triton
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-debug-online-endpoints-locally-in-visual-studio-code.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-debug-online-endpoints-locally-in-visual-studio-code.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: debug-online-endpoints-locally-in-visual-studio-code
         path: sdk/python/endpoints/online/managed
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/debug-online-endpoints-locally-in-visual-studio-code.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/online/managed/debug-online-endpoints-locally-in-visual-studio-code.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/online/managed/debug-online-endpoints-locally-in-visual-studio-code.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-debug-online-endpoints-locally-in-visual-studio-code.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-debug-online-endpoints-locally-in-visual-studio-code.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: online-endpoints-safe-rollout
         path: sdk/python/endpoints/online/managed
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-safe-rollout.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/online/managed/online-endpoints-safe-rollout.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/online/managed/online-endpoints-safe-rollout.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: online-endpoints-simple-deployment
         path: sdk/python/endpoints/online/managed
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-simple-deployment.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/online/managed/online-endpoints-simple-deployment.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/online/managed/online-endpoints-simple-deployment.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
+++ b/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: online-endpoints-deploy-mlflow-model
         path: sdk/python/endpoints/online/mlflow
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/mlflow/online-endpoints-deploy-mlflow-model.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/online/mlflow/online-endpoints-deploy-mlflow-model.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/online/mlflow/online-endpoints-deploy-mlflow-model.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
+++ b/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
+++ b/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: online-endpoints-triton
         path: sdk/python/endpoints/online/triton/single-model
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/triton/single-model/online-endpoints-triton.ipynb'"
+                Summary: |
+                    Notebook 'endpoints/online/triton/single-model/online-endpoints-triton.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "endpoints/online/triton/single-model/online-endpoints-triton.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
+++ b/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing-mlflow.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing-mlflow.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: automl-classification-task-bankmarketing-mlflow
         path: sdk/python/jobs/automl-standalone-jobs/automl-classification-task-bankmarketing
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing-mlflow.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing-mlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing-mlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: automl-classification-task-bankmarketing
         path: sdk/python/jobs/automl-standalone-jobs/automl-classification-task-bankmarketing
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: automl-forecasting-task-energy-demand-advanced-mlflow
         path: sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: automl-forecasting-task-energy-demand-advanced
         path: sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-batch-scoring-image-classification-multiclass-batch-scoring-non-mlflow-model.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-batch-scoring-image-classification-multiclass-batch-scoring-non-mlflow-model.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: image-classification-multiclass-batch-scoring-non-mlflow-model
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-batch-scoring
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-classification-multiclass-batch-scoring/image-classification-multiclass-batch-scoring-non-mlflow-model.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-image-classification-multiclass-batch-scoring/image-classification-multiclass-batch-scoring-non-mlflow-model.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-image-classification-multiclass-batch-scoring/image-classification-multiclass-batch-scoring-non-mlflow-model.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-batch-scoring-image-classification-multiclass-batch-scoring-non-mlflow-model.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-batch-scoring-image-classification-multiclass-batch-scoring-non-mlflow-model.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: automl-image-classification-multiclass-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: automl-image-classification-multilabel-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: automl-image-instance-segmentation-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: automl-image-object-detection-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment-mlflow.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: automl-nlp-text-classification-multiclass-task-sentiment-mlflow
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-text-classification-multiclass-task-sentiment-mlflow.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-text-classification-multiclass-task-sentiment-mlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-text-classification-multiclass-task-sentiment-mlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment-mlflow.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: automl-nlp-text-classification-multiclass-task-sentiment
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-text-classification-multiclass-task-sentiment.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-text-classification-multiclass-task-sentiment.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-text-classification-multiclass-task-sentiment.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-text-classification-multiclass-task-sentiment.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-text-classification-multilabel-task-paper-cat.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-text-classification-multilabel-task-paper-cat.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: automl-nlp-text-classification-multilabel-task-paper-cat
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization/automl-nlp-text-classification-multilabel-task-paper-cat.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization/automl-nlp-text-classification-multilabel-task-paper-cat.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization/automl-nlp-text-classification-multilabel-task-paper-cat.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-text-classification-multilabel-task-paper-cat.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-text-classification-multilabel-task-paper-cat.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: automl-nlp-text-ner-task
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task/automl-nlp-text-ner-task.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task/automl-nlp-text-ner-task.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task/automl-nlp-text-ner-task.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: automl-regression-task-hardware-performance
         path: sdk/python/jobs/automl-standalone-jobs/automl-regression-task-hardware-performance
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-regression-task-hardware-performance/automl-regression-task-hardware-performance.ipynb'"
+                Summary: |
+                    Notebook 'jobs/automl-standalone-jobs/automl-regression-task-hardware-performance/automl-regression-task-hardware-performance.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/automl-standalone-jobs/automl-regression-task-hardware-performance/automl-regression-task-hardware-performance.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-configuration.yml
+++ b/.github/workflows/sdk-jobs-configuration.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: configuration
         path: sdk/python/jobs
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/configuration.ipynb'"
+                Summary: |
+                    Notebook 'jobs/configuration.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/configuration.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-configuration.yml
+++ b/.github/workflows/sdk-jobs-configuration.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: pipeline_with_components_from_yaml
         path: sdk/python/jobs/pipelines/1a_pipeline_with_components_from_yaml
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1a_pipeline_with_components_from_yaml/pipeline_with_components_from_yaml.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1a_pipeline_with_components_from_yaml/pipeline_with_components_from_yaml.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1a_pipeline_with_components_from_yaml/pipeline_with_components_from_yaml.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: pipeline_with_python_function_components
         path: sdk/python/jobs/pipelines/1b_pipeline_with_python_function_components
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1b_pipeline_with_python_function_components/pipeline_with_python_function_components.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1b_pipeline_with_python_function_components/pipeline_with_python_function_components.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1b_pipeline_with_python_function_components/pipeline_with_python_function_components.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: pipeline_with_hyperparameter_sweep
         path: sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: pipeline_with_non_python_components
         path: sdk/python/jobs/pipelines/1d_pipeline_with_non_python_components
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1d_pipeline_with_non_python_components/pipeline_with_non_python_components.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1d_pipeline_with_non_python_components/pipeline_with_non_python_components.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1d_pipeline_with_non_python_components/pipeline_with_non_python_components.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: pipeline_with_registered_components
         path: sdk/python/jobs/pipelines/1e_pipeline_with_registered_components
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1e_pipeline_with_registered_components/pipeline_with_registered_components.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1e_pipeline_with_registered_components/pipeline_with_registered_components.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1e_pipeline_with_registered_components/pipeline_with_registered_components.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: pipeline_with_parallel_nodes
         path: sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-classification-bankmarketing-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline/automl-classification-bankmarketing-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline/automl-classification-bankmarketing-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline/automl-classification-bankmarketing-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-forecasting-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-image-classification-multiclass-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline/automl-image-classification-multiclass-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline/automl-image-classification-multiclass-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline/automl-image-classification-multiclass-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-image-classification-multilabel-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline/automl-image-classification-multilabel-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline/automl-image-classification-multilabel-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline/automl-image-classification-multilabel-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-image-instance-segmentation-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-image-object-detection-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline/automl-image-object-detection-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline/automl-image-object-detection-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline/automl-image-object-detection-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-regression-house-pricing-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline/automl-regression-house-pricing-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline/automl-regression-house-pricing-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline/automl-regression-house-pricing-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline-automl-text-classification-multilabel-paper-categorization-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-text-classification-multilabel-paper-categorization-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-paper-categorization-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-paper-categorization-in-pipeline/automl-text-classification-multilabel-paper-categorization-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-paper-categorization-in-pipeline/automl-text-classification-multilabel-paper-categorization-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-paper-categorization-in-pipeline/automl-text-classification-multilabel-paper-categorization-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-sentiment-in-pipeline-automl-text-classification-sentiment-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-sentiment-in-pipeline-automl-text-classification-sentiment-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-sentiment-in-pipeline-automl-text-classification-sentiment-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-sentiment-in-pipeline-automl-text-classification-sentiment-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-text-classification-sentiment-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-sentiment-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-sentiment-in-pipeline/automl-text-classification-sentiment-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-sentiment-in-pipeline/automl-text-classification-sentiment-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-sentiment-in-pipeline/automl-text-classification-sentiment-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: automl-text-ner-named-entity-recognition-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline/automl-text-ner-named-entity-recognition-in-pipeline.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline/automl-text-ner-named-entity-recognition-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline/automl-text-ner-named-entity-recognition-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: train_mnist_with_tensorflow
         path: sdk/python/jobs/pipelines/2a_train_mnist_with_tensorflow
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2a_train_mnist_with_tensorflow/train_mnist_with_tensorflow.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/2a_train_mnist_with_tensorflow/train_mnist_with_tensorflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/2a_train_mnist_with_tensorflow/train_mnist_with_tensorflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: train_cifar_10_with_pytorch
         path: sdk/python/jobs/pipelines/2b_train_cifar_10_with_pytorch
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2b_train_cifar_10_with_pytorch/train_cifar_10_with_pytorch.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/2b_train_cifar_10_with_pytorch/train_cifar_10_with_pytorch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/2b_train_cifar_10_with_pytorch/train_cifar_10_with_pytorch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: nyc_taxi_data_regression
         path: sdk/python/jobs/pipelines/2c_nyc_taxi_data_regression
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2c_nyc_taxi_data_regression/nyc_taxi_data_regression.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/2c_nyc_taxi_data_regression/nyc_taxi_data_regression.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/2c_nyc_taxi_data_regression/nyc_taxi_data_regression.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: image_classification_with_densenet
         path: sdk/python/jobs/pipelines/2d_image_classification_with_densenet
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2d_image_classification_with_densenet/image_classification_with_densenet.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/2d_image_classification_with_densenet/image_classification_with_densenet.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/2d_image_classification_with_densenet/image_classification_with_densenet.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: image_classification_keras_minist_convnet
         path: sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2e_image_classification_keras_minist_convnet/image_classification_keras_minist_convnet.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/2e_image_classification_keras_minist_convnet/image_classification_keras_minist_convnet.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/2e_image_classification_keras_minist_convnet/image_classification_keras_minist_convnet.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2f_rai_pipeline_sample-rai_pipeline_sample.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2f_rai_pipeline_sample-rai_pipeline_sample.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2f_rai_pipeline_sample-rai_pipeline_sample.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2f_rai_pipeline_sample-rai_pipeline_sample.yml
@@ -51,3 +51,22 @@ jobs:
       with:
         name: rai_pipeline_sample
         path: sdk/python/jobs/pipelines/2f_rai_pipeline_sample
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2f_rai_pipeline_sample/rai_pipeline_sample.ipynb'"
+                Summary: |
+                    Notebook 'jobs/pipelines/2f_rai_pipeline_sample/rai_pipeline_sample.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/pipelines/2f_rai_pipeline_sample/rai_pipeline_sample.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
+++ b/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
+++ b/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: lightgbm-iris-sweep
         path: sdk/python/jobs/single-step/lightgbm/iris
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/lightgbm/iris/lightgbm-iris-sweep.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/lightgbm/iris/lightgbm-iris-sweep.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/lightgbm/iris/lightgbm-iris-sweep.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-pytorch-distributed training-distributed-cifar10.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-distributed training-distributed-cifar10.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-pytorch-distributed training-distributed-cifar10.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-distributed training-distributed-cifar10.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: distributed-cifar10
         path: sdk/python/jobs/single-step/pytorch/distributed training
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/pytorch/distributed training/distributed-cifar10.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/pytorch/distributed training/distributed-cifar10.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/pytorch/distributed training/distributed-cifar10.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: pytorch-iris
         path: sdk/python/jobs/single-step/pytorch/iris
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/pytorch/iris/pytorch-iris.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/pytorch/iris/pytorch-iris.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/pytorch/iris/pytorch-iris.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: train-hyperparameter-tune-deploy-with-pytorch
         path: sdk/python/jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
+++ b/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: accident-prediction
         path: sdk/python/jobs/single-step/r/accidents
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/r/accidents/accident-prediction.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/r/accidents/accident-prediction.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/r/accidents/accident-prediction.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
+++ b/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: sklearn-diabetes
         path: sdk/python/jobs/single-step/scikit-learn/diabetes
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/scikit-learn/diabetes/sklearn-diabetes.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/scikit-learn/diabetes/sklearn-diabetes.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/scikit-learn/diabetes/sklearn-diabetes.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: iris-scikit-learn
         path: sdk/python/jobs/single-step/scikit-learn/iris
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/scikit-learn/iris/iris-scikit-learn.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/scikit-learn/iris/iris-scikit-learn.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/scikit-learn/iris/iris-scikit-learn.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: sklearn-mnist
         path: sdk/python/jobs/single-step/scikit-learn/mnist
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/scikit-learn/mnist/sklearn-mnist.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/scikit-learn/mnist/sklearn-mnist.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/scikit-learn/mnist/sklearn-mnist.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-train-hyperparameter-tune-deploy-with-sklearn-train-hyperparameter-tune-with-sklearn.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-train-hyperparameter-tune-deploy-with-sklearn-train-hyperparameter-tune-with-sklearn.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-train-hyperparameter-tune-deploy-with-sklearn-train-hyperparameter-tune-with-sklearn.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-train-hyperparameter-tune-deploy-with-sklearn-train-hyperparameter-tune-with-sklearn.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         name: train-hyperparameter-tune-with-sklearn
         path: sdk/python/jobs/single-step/scikit-learn/train-hyperparameter-tune-deploy-with-sklearn
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/scikit-learn/train-hyperparameter-tune-deploy-with-sklearn/train-hyperparameter-tune-with-sklearn.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/scikit-learn/train-hyperparameter-tune-deploy-with-sklearn/train-hyperparameter-tune-with-sklearn.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/scikit-learn/train-hyperparameter-tune-deploy-with-sklearn/train-hyperparameter-tune-with-sklearn.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: tensorflow-mnist-distributed-horovod
         path: sdk/python/jobs/single-step/tensorflow/mnist-distributed-horovod
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/mnist-distributed-horovod/tensorflow-mnist-distributed-horovod.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/tensorflow/mnist-distributed-horovod/tensorflow-mnist-distributed-horovod.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/tensorflow/mnist-distributed-horovod/tensorflow-mnist-distributed-horovod.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: tensorflow-mnist-distributed
         path: sdk/python/jobs/single-step/tensorflow/mnist-distributed
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/mnist-distributed/tensorflow-mnist-distributed.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/tensorflow/mnist-distributed/tensorflow-mnist-distributed.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/tensorflow/mnist-distributed/tensorflow-mnist-distributed.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: tensorflow-mnist
         path: sdk/python/jobs/single-step/tensorflow/mnist
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/mnist/tensorflow-mnist.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/tensorflow/mnist/tensorflow-mnist.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/tensorflow/mnist/tensorflow-mnist.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-keras-train-hyperparameter-tune-deploy-with-keras.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-keras-train-hyperparameter-tune-deploy-with-keras.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-keras-train-hyperparameter-tune-deploy-with-keras.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-keras-train-hyperparameter-tune-deploy-with-keras.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: train-hyperparameter-tune-deploy-with-keras
         path: sdk/python/jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-keras
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-keras/train-hyperparameter-tune-deploy-with-keras.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-keras/train-hyperparameter-tune-deploy-with-keras.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-keras/train-hyperparameter-tune-deploy-with-keras.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: train-hyperparameter-tune-deploy-with-tensorflow
         path: sdk/python/jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-tensorflow
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-tensorflow/train-hyperparameter-tune-deploy-with-tensorflow.ipynb'"
+                Summary: |
+                    Notebook 'jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-tensorflow/train-hyperparameter-tune-deploy-with-tensorflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-tensorflow/train-hyperparameter-tune-deploy-with-tensorflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow-train-hyperparameter-tune-deploy-with-tensorflow.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-resources-compute-compute.yml
+++ b/.github/workflows/sdk-resources-compute-compute.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: compute
         path: sdk/python/resources/compute
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'resources/compute/compute.ipynb'"
+                Summary: |
+                    Notebook 'resources/compute/compute.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "resources/compute/compute.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-resources-compute-compute.yml
+++ b/.github/workflows/sdk-resources-compute-compute.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-resources-workspace-workspace.yml
+++ b/.github/workflows/sdk-resources-workspace-workspace.yml
@@ -59,3 +59,22 @@ jobs:
       with:
         name: workspace
         path: sdk/python/resources/workspace
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'resources/workspace/workspace.ipynb'"
+                Summary: |
+                    Notebook 'resources/workspace/workspace.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "resources/workspace/workspace.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-resources-workspace-workspace.yml
+++ b/.github/workflows/sdk-resources-workspace-workspace.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/.github/workflows/sdk-schedules-job-schedule.yml
+++ b/.github/workflows/sdk-schedules-job-schedule.yml
@@ -52,3 +52,22 @@ jobs:
       with:
         name: job-schedule
         path: sdk/python/schedules
+
+    - name: Send IcM on failure
+      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
+        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
+        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
+        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'schedules/job-schedule.ipynb'"
+                Summary: |
+                    Notebook 'schedules/job-schedule.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "schedules/job-schedule.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-schedules-job-schedule.yml
+++ b/.github/workflows/sdk-schedules-job-schedule.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Send IcM on failure
       if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
         connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}

--- a/sdk/python/readme.py
+++ b/sdk/python/readme.py
@@ -191,6 +191,26 @@ jobs:
         name: {name}
         path: sdk/python/{posix_folder}\n"""
 
+    workflow_yaml += f"""
+    - name: Send IcM on failure
+      if: ${{{{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}}}
+      uses: .github/actions/generate-icm
+      with:
+        host: ${{{{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}}}
+        connector_id: ${{{{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}}}
+        certificate: ${{{{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}}}
+        private_key: ${{{{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}}}
+        args: |
+            incident:
+                Title: "[azureml-examples] Notebook validation failed on branch '${{{{ github.ref_name }}}}' for notebook '{posix_notebook}'"
+                Summary: |
+                    Notebook '{posix_notebook}' is failing on branch '${{{{ github.ref_name }}}}': ${{{{ github.server_url }}}}/${{{{ github.repository }}}}/actions/runs/${{{{ github.run_id }}}}
+                Severity: 4
+                RoutingId: "github://azureml-examples"
+                Status: Active
+                Source:
+                    IncidentId: "{posix_notebook}[${{{{ github.ref_name }}}}]"\n"""
+
     workflow_file = os.path.join(
         "..", "..", ".github", "workflows", f"sdk-{classification}-{name}.yml"
     )

--- a/sdk/python/readme.py
+++ b/sdk/python/readme.py
@@ -194,7 +194,7 @@ jobs:
     workflow_yaml += f"""
     - name: Send IcM on failure
       if: ${{{{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}}}
-      uses: .github/actions/generate-icm
+      uses: ./.github/actions/generate-icm
       with:
         host: ${{{{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}}}
         connector_id: ${{{{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}}}


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

This pull-request adds an extra step to notebook validation that fires an IcM when notebook validation fails (see `sdk/readme.py`)

`readme.py` was run to regenerate relevant worklows.


