### PR TITLE
[pipeline] Fix mldesigner version for sdk

### DIFF
--- a/sdk/setup.sh
+++ b/sdk/setup.sh
@@ -5,7 +5,7 @@ pip install --pre azure-ai-ml
 # </az_ml_sdk_install>
 
 # <mldesigner_install>
-pip install mldesigner
+pip install mldesigner==0.1.0b4
 # </mldesigner_install>
 
 # <mltable_install>


### PR DESCRIPTION
# PR into Azure/azureml-examples
Fix mldeisgner version to b4, as azure-ai-ml b7 is not released yet.

## Checklist

I have:

- [ ] read and followed the contributing guidelines

## Changes

-

fixes #

