### PR TITLE
Nvijayrania/remove pinning for scikit image

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -228,7 +228,7 @@
    "source": [
     "# The jsonl_converter below relies on scikit-image and simplification.\n",
     "# If you don't have them installed, install them before converting data by runing this cell.\n",
-    "%pip install \"scikit-image==0.17.2\" \"simplification\""
+    "%pip install \"scikit-image\" \"simplification\""
    ]
   },
   {

--- a/sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb
+++ b/sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb
@@ -336,9 +336,9 @@
    "description": "Create pipeline with automl node"
   },
   "kernelspec": {
-   "display_name": "Python [conda env:v2_bugbash]",
+   "display_name": "Python 3.10.0 ('sdk-cli-v2')",
    "language": "python",
-   "name": "conda-env-v2_bugbash-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb
+++ b/sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb
@@ -183,7 +183,7 @@
    "source": [
     "# The jsonl_converter below relies on scikit-image and simplification.\n",
     "# If you don't have them installed, install them before converting data by runing this cell.\n",
-    "%pip install \"scikit-image==0.17.2\" \"simplification\""
+    "%pip install \"scikit-image\" \"simplification\""
    ]
   },
   {
@@ -336,9 +336,9 @@
    "description": "Create pipeline with automl node"
   },
   "kernelspec": {
-   "display_name": "Python 3.10.0 ('sdk-cli-v2')",
+   "display_name": "Python [conda env:v2_bugbash]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-v2_bugbash-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- With a conda environment crreated out of python 3.10, scikit-image 0.17.2 creates a conflict and is failing. This PR removes the pinning of scikit-image since the old version 0.17.2 is outdated(relased in 2020), so this PR unpins the version of scikit-image.
Tested with python 3.7 and 3.10. It works

fixes #

