### PR TITLE
Fix hyperparameter notebooks

### DIFF
--- a/sdk/python/jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb
+++ b/sdk/python/jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb
@@ -474,7 +474,7 @@
                 "    tags={\"data\": \"birds\", \"method\": \"transfer learning\", \"framework\": \"pytorch\"},\n",
                 ")\n",
                 "\n",
-                "endpoint = ml_client.begin_create_or_update(endpoint)\n",
+                "endpoint = ml_client.begin_create_or_update(endpoint).result()\n",
                 "\n",
                 "print(f\"Endpoint {endpoint.name} provisioning state: {endpoint.provisioning_state}\")"
             ]
@@ -543,7 +543,7 @@
                 "    instance_count=1,\n",
                 ")\n",
                 "\n",
-                "blue_deployment = ml_client.begin_create_or_update(blue_deployment)"
+                "blue_deployment = ml_client.begin_create_or_update(blue_deployment).result()"
             ]
         },
         {

--- a/sdk/python/jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-tensorflow/train-hyperparameter-tune-deploy-with-tensorflow.ipynb
+++ b/sdk/python/jobs/single-step/tensorflow/train-hyperparameter-tune-deploy-with-tensorflow/train-hyperparameter-tune-deploy-with-tensorflow.ipynb
@@ -536,7 +536,7 @@
     "    auth_mode=\"key\",\n",
     ")\n",
     "\n",
-    "endpoint = ml_client.begin_create_or_update(endpoint)\n",
+    "endpoint = ml_client.begin_create_or_update(endpoint).result()\n",
     "\n",
     "print(f\"Endpint {endpoint.name} provisioning state: {endpoint.provisioning_state}\")"
    ]
@@ -602,7 +602,7 @@
     "    instance_count=1,\n",
     ")\n",
     "\n",
-    "blue_deployment = ml_client.begin_create_or_update(blue_deployment)"
+    "blue_deployment = ml_client.begin_create_or_update(blue_deployment).result()"
    ]
   },
   {


### PR DESCRIPTION
# PR into Azure/azureml-examples

Failing notebooks: `train-hyperparameter-tune-deploy-with-pytorch` and `train-hyperparameter-tune-deploy-with-tensorflow` for not getting the LROPoller result.

## Checklist

I have:

- [ ] read and followed the contributing guidelines

## Changes

-

fixes #

