### PR TITLE
change paths into specific k8s endpoint dir

### DIFF
--- a/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     paths:
-      - cli/endpoints/online/**
+      - cli/endpoints/online/kubernetes/**
       - cli/deploy-safe-rollout-kubernetes-online-endpoints.sh
       - .github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
       - cli/setup.sh


### PR DESCRIPTION
# PR into Azure/azureml-examples
Changed target path for runners from entire `cli/endpoints/online` directory into specific k8s endpoint directory.
The problem to solve is the runner launch and raises an error when we commit an example for managed online endpoints, not for k8s online endpoints.

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

-

fixes #

