### PR TITLE
Remove compute, when notebook run is completed.

### DIFF
--- a/sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb
+++ b/sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb
@@ -813,6 +813,22 @@
     "job_schedule.is_enabled\n",
     "ml_client.schedules.begin_delete(name=schedule_name).wait()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.4 [Optional] Delete the compute cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ml_client.compute.begin_delete(name=cluster_name).wait()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

-I have added compute cluster removal after the notebook is complete. This will free up a resources on our gates as currently we are running all notebooks in one workspace and clean it up only at midnight.

fixes #

