### PR TITLE
patch: MINST batch score.py to return pandas instead of list (which is the recommended)

### DIFF
--- a/cli/endpoints/batch/mnist/code/batch_driver.py
+++ b/cli/endpoints/batch/mnist/code/batch_driver.py
@@ -3,6 +3,7 @@
 
 import os
 import numpy as np
+import pandas as pd
 import tensorflow as tf
 from PIL import Image
 from azureml.core import Model
@@ -37,6 +38,6 @@ def run(mini_batch):
         inference_result = output.eval(feed_dict={in_tensor: np_im}, session=g_tf_sess)
         # find best probability, and add to result list
         best_result = np.argmax(inference_result)
-        resultList.append("{}: {}".format(os.path.basename(image), best_result))
+        resultList.append([os.path.basename(image), best_result])
 
-    return resultList
+    return pd.DataFrame(resultList)

--- a/cli/endpoints/batch/mnist/environment/conda.yml
+++ b/cli/endpoints/batch/mnist/environment/conda.yml
@@ -7,5 +7,6 @@ dependencies:
   - pip:
     - tensorflow==1.15.2
     - pillow
+    - pandas
     - azureml-core
     - azureml-dataset-runtime[fuse]

--- a/sdk/python/endpoints/batch/mnist/code/batch_driver.py
+++ b/sdk/python/endpoints/batch/mnist/code/batch_driver.py
@@ -3,6 +3,7 @@
 
 import os
 import numpy as np
+import pandas as pd
 import tensorflow as tf
 from PIL import Image
 from azureml.core import Model
@@ -37,6 +38,6 @@ def run(mini_batch):
         inference_result = output.eval(feed_dict={in_tensor: np_im}, session=g_tf_sess)
         # find best probability, and add to result list
         best_result = np.argmax(inference_result)
-        resultList.append("{}: {}".format(os.path.basename(image), best_result))
+        resultList.append([os.path.basename(image), best_result])
 
-    return resultList
+    return pd.DataFrame(resultList)

--- a/sdk/python/endpoints/batch/mnist/environment/conda.yml
+++ b/sdk/python/endpoints/batch/mnist/environment/conda.yml
@@ -7,5 +7,6 @@ dependencies:
   - pip:
     - tensorflow==1.15.2
     - pillow
+    - pandas
     - azureml-core
     - azureml-dataset-runtime[fuse]


### PR DESCRIPTION
# PR into Azure/azureml-examples

## Checklist

I have:

- [ x ] read and followed the contributing guidelines

## Changes

- Scoring script for batch endpoint example MNIST to return pandas instead of list (which is the recommended way).

fixes #

