### PR TITLE
Potential fix for auto-ml-image-segmentation job failure due to timeout

### DIFF
--- a/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
@@ -435,7 +435,7 @@
     "}\n",
     "\n",
     "tuning_settings = {\n",
-    "    \"iterations\": 4,\n",
+    "    \"iterations\": 6,\n",
     "    \"max_concurrent_iterations\": 2,\n",
     "    \"hyperparameter_sampling\": RandomParameterSampling(parameter_space),\n",
     "    \"early_termination_policy\": BanditPolicy(\n",

--- a/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
@@ -435,7 +435,7 @@
     "}\n",
     "\n",
     "tuning_settings = {\n",
-    "    \"iterations\": 10,\n",
+    "    \"iterations\": 4,\n",
     "    \"max_concurrent_iterations\": 2,\n",
     "    \"hyperparameter_sampling\": RandomParameterSampling(parameter_space),\n",
     "    \"early_termination_policy\": BanditPolicy(\n",
@@ -748,9 +748,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8 - AzureML",
+   "display_name": "Python 3.7.10 ('dpv2')",
    "language": "python",
-   "name": "python38-azureml"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -766,6 +766,11 @@
   },
   "nteract": {
    "version": "nteract-front-end@1.0.0"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "9131a0e033fe3daaaa2d1a4edf9f8cdc670f97733b531f4e18c5a20b60931c6e"
+   }
   }
  },
  "nbformat": 4,

--- a/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
@@ -766,7 +766,7 @@
   },
   "nteract": {
    "version": "nteract-front-end@1.0.0"
-  },
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/image-instance-segmentation/auto-ml-image-instance-segmentation.ipynb
@@ -748,9 +748,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 ('dpv2')",
+   "display_name": "Python 3.8 - AzureML",
    "language": "python",
-   "name": "python3"
+   "name": "python38-azureml"
   },
   "language_info": {
    "codemirror_mode": {
@@ -767,11 +767,6 @@
   "nteract": {
    "version": "nteract-front-end@1.0.0"
   },
-  "vscode": {
-   "interpreter": {
-    "hash": "9131a0e033fe3daaaa2d1a4edf9f8cdc670f97733b531f4e18c5a20b60931c6e"
-   }
-  }
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
# Description
The image-instance-segmentation notebook is failing due to cell_timeout while sweeping. The PR reduces the number of iterations while sweeping to finish execution before timeout i.e. 60 mins.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
