### PR TITLE
Modify batch inferencing scripts to avoid loading non csv files

### DIFF
--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
@@ -17,6 +17,7 @@ on:
       - sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/**
       - .github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
       - sdk/python/dev-requirements.txt
+      - sdk/python/forecasting-requirements.txt
       - infra/**
       - sdk/python/setup.sh
 concurrency:
@@ -36,6 +37,8 @@ jobs:
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
+    - name: pip install forecasting reqs
+      run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
       uses: azure/login@v1
       with:

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
@@ -17,6 +17,7 @@ on:
       - sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/**
       - .github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
       - sdk/python/dev-requirements.txt
+      - sdk/python/forecasting-requirements.txt
       - infra/**
       - sdk/python/setup.sh
 concurrency:
@@ -36,6 +37,8 @@ jobs:
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
+    - name: pip install forecasting reqs
+      run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
       uses: azure/login@v1
       with:

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/helpers/forecasting_script.py
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/helpers/forecasting_script.py
@@ -32,6 +32,8 @@ def run(mini_batch):
     print(f"run method start: {__file__}, run({mini_batch})")
     resultList = []
     for test in mini_batch:
+        if not test.endswith(".csv"):
+            continue
         X_test = pd.read_csv(test, parse_dates=[fitted_model.time_column_name])
         y_test = X_test.pop(target_column_name).values
 

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/forecast/rolling_script.py
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/forecast/rolling_script.py
@@ -29,6 +29,8 @@ def run(mini_batch):
     print(f"run method start: {__file__}, run({mini_batch})")
     resultList = []
     for test in mini_batch:
+        if not test.endswith(".csv"):
+            continue
         X_test = pd.read_csv(test, parse_dates=[fitted_model.time_column_name])
         y_test = X_test.pop(target_column_name).values
 

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/forecast/forecasting_script.py
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/forecast/forecasting_script.py
@@ -29,6 +29,8 @@ def run(mini_batch):
     print(f"run method start: {__file__}, run({mini_batch})")
     resultList = []
     for test in mini_batch:
+        if not test.endswith(".csv"):
+            continue
         X_test = pd.read_csv(test, parse_dates=[fitted_model.time_column_name])
         y_test = X_test.pop(target_column_name).values
 


### PR DESCRIPTION
# Description
**Problem:** When we are inferencing on the batch endpoint we are providing the URI, which may contain several files, some of which cannot be a valid csv.
**Solution:** Skip csv files while reading files.
**Bug:** 2071742.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
