### PR TITLE
Migrate IcM generation to monitor

### DIFF
--- a/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: share-models-components-environments
         path: sdk/python/assets/assets-in-registry
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/assets-in-registry/share-models-components-environments.ipynb'"
-                Summary: |
-                    Notebook 'assets/assets-in-registry/share-models-components-environments.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "assets/assets-in-registry/share-models-components-environments.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-component-component.yml
+++ b/.github/workflows/sdk-assets-component-component.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: component
         path: sdk/python/assets/component
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/component/component.ipynb'"
-                Summary: |
-                    Notebook 'assets/component/component.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "assets/component/component.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-data-data.yml
+++ b/.github/workflows/sdk-assets-data-data.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: data
         path: sdk/python/assets/data
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/data/data.ipynb'"
-                Summary: |
-                    Notebook 'assets/data/data.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "assets/data/data.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-data-working_with_mltable.yml
+++ b/.github/workflows/sdk-assets-data-working_with_mltable.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: working_with_mltable
         path: sdk/python/assets/data
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/data/working_with_mltable.ipynb'"
-                Summary: |
-                    Notebook 'assets/data/working_with_mltable.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "assets/data/working_with_mltable.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-environment-environment.yml
+++ b/.github/workflows/sdk-assets-environment-environment.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: environment
         path: sdk/python/assets/environment
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/environment/environment.ipynb'"
-                Summary: |
-                    Notebook 'assets/environment/environment.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "assets/environment/environment.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-assets-model-model.yml
+++ b/.github/workflows/sdk-assets-model-model.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: model
         path: sdk/python/assets/model
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'assets/model/model.ipynb'"
-                Summary: |
-                    Notebook 'assets/model/model.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "assets/model/model.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-batch-custom-output-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-custom-output-batch.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: custom-output-batch
         path: sdk/python/endpoints/batch
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/batch/custom-output-batch.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/batch/custom-output-batch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/batch/custom-output-batch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-batch-imagenet-classifier-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-imagenet-classifier-batch.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: imagenet-classifier-batch
         path: sdk/python/endpoints/batch
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/batch/imagenet-classifier-batch.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/batch/imagenet-classifier-batch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/batch/imagenet-classifier-batch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-batch-mlflow-for-batch-tabular.yml
+++ b/.github/workflows/sdk-endpoints-batch-mlflow-for-batch-tabular.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: mlflow-for-batch-tabular
         path: sdk/python/endpoints/batch
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/batch/mlflow-for-batch-tabular.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/batch/mlflow-for-batch-tabular.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/batch/mlflow-for-batch-tabular.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-batch-mnist-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-mnist-batch.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: mnist-batch
         path: sdk/python/endpoints/batch
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/batch/mnist-batch.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/batch/mnist-batch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/batch/mnist-batch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-batch-text-summarization-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-text-summarization-batch.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: text-summarization-batch
         path: sdk/python/endpoints/batch
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/batch/text-summarization-batch.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/batch/text-summarization-batch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/batch/text-summarization-batch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-custom-container-multimodel
         path: sdk/python/endpoints/online/custom-container
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/custom-container/online-endpoints-custom-container-multimodel.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/custom-container/online-endpoints-custom-container-multimodel.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/custom-container/online-endpoints-custom-container-multimodel.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-custom-container
         path: sdk/python/endpoints/online/custom-container
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/custom-container/online-endpoints-custom-container.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/custom-container/online-endpoints-custom-container.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/custom-container/online-endpoints-custom-container.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-triton-cc
         path: sdk/python/endpoints/online/custom-container/triton
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-safe-rollout.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: kubernetes-online-endpoints-safe-rollout
         path: sdk/python/endpoints/online/kubernetes
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/kubernetes/kubernetes-online-endpoints-safe-rollout.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/kubernetes/kubernetes-online-endpoints-safe-rollout.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/kubernetes/kubernetes-online-endpoints-safe-rollout.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-simple-deployment.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: kubernetes-online-endpoints-simple-deployment
         path: sdk/python/endpoints/online/kubernetes
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/kubernetes/kubernetes-online-endpoints-simple-deployment.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/kubernetes/kubernetes-online-endpoints-simple-deployment.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/kubernetes/kubernetes-online-endpoints-simple-deployment.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-managed-identity-sai
         path: sdk/python/endpoints/online/managed/managed-identities
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/managed-identities/online-endpoints-managed-identity-sai.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/managed-identities/online-endpoints-managed-identity-sai.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/managed-identities/online-endpoints-managed-identity-sai.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-managed-identity-uai
         path: sdk/python/endpoints/online/managed/managed-identities
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-binary-payloads
         path: sdk/python/endpoints/online/managed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-binary-payloads.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/online-endpoints-binary-payloads.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/online-endpoints-binary-payloads.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-inference-schema
         path: sdk/python/endpoints/online/managed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-inference-schema.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/online-endpoints-inference-schema.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/online-endpoints-inference-schema.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-keyvault
         path: sdk/python/endpoints/online/managed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-keyvault.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/online-endpoints-keyvault.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/online-endpoints-keyvault.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-multimodel
         path: sdk/python/endpoints/online/managed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-multimodel.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/online-endpoints-multimodel.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/online-endpoints-multimodel.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-openapi
         path: sdk/python/endpoints/online/managed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-openapi.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/online-endpoints-openapi.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/online-endpoints-openapi.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-safe-rollout
         path: sdk/python/endpoints/online/managed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-safe-rollout.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/online-endpoints-safe-rollout.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/online-endpoints-safe-rollout.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-simple-deployment
         path: sdk/python/endpoints/online/managed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/managed/online-endpoints-simple-deployment.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/managed/online-endpoints-simple-deployment.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/managed/online-endpoints-simple-deployment.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
+++ b/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-deploy-mlflow-model
         path: sdk/python/endpoints/online/mlflow
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/mlflow/online-endpoints-deploy-mlflow-model.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/mlflow/online-endpoints-deploy-mlflow-model.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/mlflow/online-endpoints-deploy-mlflow-model.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
+++ b/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: online-endpoints-triton
         path: sdk/python/endpoints/online/triton/single-model
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'endpoints/online/triton/single-model/online-endpoints-triton.ipynb'"
-                Summary: |
-                    Notebook 'endpoints/online/triton/single-model/online-endpoints-triton.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "endpoints/online/triton/single-model/online-endpoints-triton.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing-mlflow.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-classification-task-bankmarketing-mlflow
         path: sdk/python/jobs/automl-standalone-jobs/automl-classification-task-bankmarketing
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing-mlflow.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing-mlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing-mlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-classification-task-bankmarketing
         path: sdk/python/jobs/automl-standalone-jobs/automl-classification-task-bankmarketing
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
@@ -78,22 +78,3 @@ jobs:
 
     - name: Remove the compute if notebook did not done it properly.
       run: bash "${{ github.workspace }}/infra/remove_computes.sh" github-cluster-sdkv2
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
@@ -80,22 +80,3 @@ jobs:
 
     - name: Remove the compute if notebook did not done it properly.
       run: bash "${{ github.workspace }}/infra/remove_computes.sh" oj-cluster
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
@@ -80,22 +80,3 @@ jobs:
 
     - name: Remove the compute if notebook did not done it properly.
       run: bash "${{ github.workspace }}/infra/remove_computes.sh" bike-share-v2
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
@@ -80,22 +80,3 @@ jobs:
 
     - name: Remove the compute if notebook did not done it properly.
       run: bash "${{ github.workspace }}/infra/remove_computes.sh" energy-cluster-v2
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
@@ -76,22 +76,3 @@ jobs:
 
     - name: Remove the compute if notebook did not done it properly.
       run: bash "${{ github.workspace }}/infra/remove_computes.sh" adv-energy-cluster-v2
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-image-classification-multiclass-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-image-classification-multilabel-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-image-instance-segmentation-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-image-object-detection-task-fridge-items
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: image-object-detection-batch-scoring-non-mlflow-model
         path: sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-nlp-multiclass-sentiment-mlflow
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment-mlflow.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment-mlflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment-mlflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-nlp-multiclass-sentiment
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-nlp-multilabel-paper-cat
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization/automl-nlp-multilabel-paper-cat.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization/automl-nlp-multilabel-paper-cat.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization/automl-nlp-multilabel-paper-cat.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-nlp-text-ner-task
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task/automl-nlp-text-ner-task.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task/automl-nlp-text-ner-task.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task/automl-nlp-text-ner-task.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: automl-nlp-text-ner-task-distributed-with-sweeping
         path: sdk/python/jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task-distributed-sweeping
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task-distributed-sweeping/automl-nlp-text-ner-task-distributed-with-sweeping.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task-distributed-sweeping/automl-nlp-text-ner-task-distributed-with-sweeping.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task-distributed-sweeping/automl-nlp-text-ner-task-distributed-with-sweeping.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-regression-task-hardware-performance
         path: sdk/python/jobs/automl-standalone-jobs/automl-regression-task-hardware-performance
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/automl-standalone-jobs/automl-regression-task-hardware-performance/automl-regression-task-hardware-performance.ipynb'"
-                Summary: |
-                    Notebook 'jobs/automl-standalone-jobs/automl-regression-task-hardware-performance/automl-regression-task-hardware-performance.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/automl-standalone-jobs/automl-regression-task-hardware-performance/automl-regression-task-hardware-performance.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-configuration.yml
+++ b/.github/workflows/sdk-jobs-configuration.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: configuration
         path: sdk/python/jobs
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/configuration.ipynb'"
-                Summary: |
-                    Notebook 'jobs/configuration.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/configuration.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: pipeline_with_components_from_yaml
         path: sdk/python/jobs/pipelines/1a_pipeline_with_components_from_yaml
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1a_pipeline_with_components_from_yaml/pipeline_with_components_from_yaml.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1a_pipeline_with_components_from_yaml/pipeline_with_components_from_yaml.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1a_pipeline_with_components_from_yaml/pipeline_with_components_from_yaml.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: pipeline_with_python_function_components
         path: sdk/python/jobs/pipelines/1b_pipeline_with_python_function_components
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1b_pipeline_with_python_function_components/pipeline_with_python_function_components.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1b_pipeline_with_python_function_components/pipeline_with_python_function_components.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1b_pipeline_with_python_function_components/pipeline_with_python_function_components.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: pipeline_with_hyperparameter_sweep
         path: sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: pipeline_with_non_python_components
         path: sdk/python/jobs/pipelines/1d_pipeline_with_non_python_components
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1d_pipeline_with_non_python_components/pipeline_with_non_python_components.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1d_pipeline_with_non_python_components/pipeline_with_non_python_components.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1d_pipeline_with_non_python_components/pipeline_with_non_python_components.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: pipeline_with_registered_components
         path: sdk/python/jobs/pipelines/1e_pipeline_with_registered_components
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1e_pipeline_with_registered_components/pipeline_with_registered_components.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1e_pipeline_with_registered_components/pipeline_with_registered_components.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1e_pipeline_with_registered_components/pipeline_with_registered_components.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: pipeline_with_parallel_nodes
         path: sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-classification-bankmarketing-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline/automl-classification-bankmarketing-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline/automl-classification-bankmarketing-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline/automl-classification-bankmarketing-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
@@ -78,22 +78,3 @@ jobs:
 
     - name: Remove the compute if notebook did not done it properly.
       run: bash "${{ github.workspace }}/infra/remove_computes.sh" forecast-step-cluster-v2
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-image-classification-multiclass-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline/automl-image-classification-multiclass-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline/automl-image-classification-multiclass-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline/automl-image-classification-multiclass-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-image-classification-multilabel-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline/automl-image-classification-multilabel-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline/automl-image-classification-multilabel-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline/automl-image-classification-multilabel-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-image-instance-segmentation-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-image-object-detection-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline/automl-image-object-detection-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline/automl-image-object-detection-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline/automl-image-object-detection-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-regression-house-pricing-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline/automl-regression-house-pricing-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline/automl-regression-house-pricing-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline/automl-regression-house-pricing-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-in-pipeline-automl-text-classification-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-in-pipeline-automl-text-classification-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-text-classification-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-in-pipeline/automl-text-classification-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-in-pipeline/automl-text-classification-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-in-pipeline/automl-text-classification-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-in-pipeline-automl-text-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-in-pipeline-automl-text-classification-multilabel-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-text-classification-multilabel-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-in-pipeline/automl-text-classification-multilabel-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-in-pipeline/automl-text-classification-multilabel-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-in-pipeline/automl-text-classification-multilabel-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: automl-text-ner-named-entity-recognition-in-pipeline
         path: sdk/python/jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline/automl-text-ner-named-entity-recognition-in-pipeline.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline/automl-text-ner-named-entity-recognition-in-pipeline.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline/automl-text-ner-named-entity-recognition-in-pipeline.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: train_mnist_with_tensorflow
         path: sdk/python/jobs/pipelines/2a_train_mnist_with_tensorflow
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2a_train_mnist_with_tensorflow/train_mnist_with_tensorflow.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/2a_train_mnist_with_tensorflow/train_mnist_with_tensorflow.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/2a_train_mnist_with_tensorflow/train_mnist_with_tensorflow.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: train_cifar_10_with_pytorch
         path: sdk/python/jobs/pipelines/2b_train_cifar_10_with_pytorch
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2b_train_cifar_10_with_pytorch/train_cifar_10_with_pytorch.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/2b_train_cifar_10_with_pytorch/train_cifar_10_with_pytorch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/2b_train_cifar_10_with_pytorch/train_cifar_10_with_pytorch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: nyc_taxi_data_regression
         path: sdk/python/jobs/pipelines/2c_nyc_taxi_data_regression
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2c_nyc_taxi_data_regression/nyc_taxi_data_regression.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/2c_nyc_taxi_data_regression/nyc_taxi_data_regression.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/2c_nyc_taxi_data_regression/nyc_taxi_data_regression.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: image_classification_with_densenet
         path: sdk/python/jobs/pipelines/2d_image_classification_with_densenet
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2d_image_classification_with_densenet/image_classification_with_densenet.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/2d_image_classification_with_densenet/image_classification_with_densenet.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/2d_image_classification_with_densenet/image_classification_with_densenet.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: image_classification_keras_minist_convnet
         path: sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2e_image_classification_keras_minist_convnet/image_classification_keras_minist_convnet.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/2e_image_classification_keras_minist_convnet/image_classification_keras_minist_convnet.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/2e_image_classification_keras_minist_convnet/image_classification_keras_minist_convnet.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-pipelines-2f_rai_pipeline_sample-rai_pipeline_sample.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2f_rai_pipeline_sample-rai_pipeline_sample.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: rai_pipeline_sample
         path: sdk/python/jobs/pipelines/2f_rai_pipeline_sample
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/pipelines/2f_rai_pipeline_sample/rai_pipeline_sample.ipynb'"
-                Summary: |
-                    Notebook 'jobs/pipelines/2f_rai_pipeline_sample/rai_pipeline_sample.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/pipelines/2f_rai_pipeline_sample/rai_pipeline_sample.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-debug-and-monitor-debug-and-monitor.yml
+++ b/.github/workflows/sdk-jobs-single-step-debug-and-monitor-debug-and-monitor.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: debug-and-monitor
         path: sdk/python/jobs/single-step/debug-and-monitor
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/debug-and-monitor/debug-and-monitor.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/debug-and-monitor/debug-and-monitor.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/debug-and-monitor/debug-and-monitor.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
+++ b/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: lightgbm-iris-sweep
         path: sdk/python/jobs/single-step/lightgbm/iris
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/lightgbm/iris/lightgbm-iris-sweep.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/lightgbm/iris/lightgbm-iris-sweep.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/lightgbm/iris/lightgbm-iris-sweep.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-distributed-cifar10.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-distributed-cifar10.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: distributed-cifar10
         path: sdk/python/jobs/single-step/pytorch/distributed-training
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/pytorch/distributed-training/distributed-cifar10.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/pytorch/distributed-training/distributed-cifar10.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/pytorch/distributed-training/distributed-cifar10.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: pytorch-iris
         path: sdk/python/jobs/single-step/pytorch/iris
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/pytorch/iris/pytorch-iris.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/pytorch/iris/pytorch-iris.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/pytorch/iris/pytorch-iris.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: train-hyperparameter-tune-deploy-with-pytorch
         path: sdk/python/jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
+++ b/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: accident-prediction
         path: sdk/python/jobs/single-step/r/accidents
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/r/accidents/accident-prediction.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/r/accidents/accident-prediction.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/r/accidents/accident-prediction.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: sklearn-diabetes
         path: sdk/python/jobs/single-step/scikit-learn/diabetes
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/scikit-learn/diabetes/sklearn-diabetes.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/scikit-learn/diabetes/sklearn-diabetes.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/scikit-learn/diabetes/sklearn-diabetes.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: iris-scikit-learn
         path: sdk/python/jobs/single-step/scikit-learn/iris
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/scikit-learn/iris/iris-scikit-learn.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/scikit-learn/iris/iris-scikit-learn.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/scikit-learn/iris/iris-scikit-learn.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: sklearn-mnist
         path: sdk/python/jobs/single-step/scikit-learn/mnist
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/scikit-learn/mnist/sklearn-mnist.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/scikit-learn/mnist/sklearn-mnist.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/scikit-learn/mnist/sklearn-mnist.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: tensorflow-mnist-distributed-horovod
         path: sdk/python/jobs/single-step/tensorflow/mnist-distributed-horovod
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/mnist-distributed-horovod/tensorflow-mnist-distributed-horovod.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/tensorflow/mnist-distributed-horovod/tensorflow-mnist-distributed-horovod.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/tensorflow/mnist-distributed-horovod/tensorflow-mnist-distributed-horovod.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: tensorflow-mnist-distributed
         path: sdk/python/jobs/single-step/tensorflow/mnist-distributed
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/mnist-distributed/tensorflow-mnist-distributed.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/tensorflow/mnist-distributed/tensorflow-mnist-distributed.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/tensorflow/mnist-distributed/tensorflow-mnist-distributed.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: tensorflow-mnist
         path: sdk/python/jobs/single-step/tensorflow/mnist
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'jobs/single-step/tensorflow/mnist/tensorflow-mnist.ipynb'"
-                Summary: |
-                    Notebook 'jobs/single-step/tensorflow/mnist/tensorflow-mnist.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "jobs/single-step/tensorflow/mnist/tensorflow-mnist.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-resources-compute-compute.yml
+++ b/.github/workflows/sdk-resources-compute-compute.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: compute
         path: sdk/python/resources/compute
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'resources/compute/compute.ipynb'"
-                Summary: |
-                    Notebook 'resources/compute/compute.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "resources/compute/compute.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-resources-connections-connections.yml
+++ b/.github/workflows/sdk-resources-connections-connections.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: connections
         path: sdk/python/resources/connections
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'resources/connections/connections.ipynb'"
-                Summary: |
-                    Notebook 'resources/connections/connections.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "resources/connections/connections.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-resources-registry-registry-create.yml
+++ b/.github/workflows/sdk-resources-registry-registry-create.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: registry-create
         path: sdk/python/resources/registry
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'resources/registry/registry-create.ipynb'"
-                Summary: |
-                    Notebook 'resources/registry/registry-create.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "resources/registry/registry-create.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-resources-workspace-workspace.yml
+++ b/.github/workflows/sdk-resources-workspace-workspace.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: workspace
         path: sdk/python/resources/workspace
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'resources/workspace/workspace.ipynb'"
-                Summary: |
-                    Notebook 'resources/workspace/workspace.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "resources/workspace/workspace.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-responsible-ai-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: responsibleaidashboard-diabetes-decision-making
         path: sdk/python/responsible-ai/responsibleaidashboard-diabetes-decision-making
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'responsible-ai/responsibleaidashboard-diabetes-decision-making/responsibleaidashboard-diabetes-decision-making.ipynb'"
-                Summary: |
-                    Notebook 'responsible-ai/responsibleaidashboard-diabetes-decision-making/responsibleaidashboard-diabetes-decision-making.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "responsible-ai/responsibleaidashboard-diabetes-decision-making/responsibleaidashboard-diabetes-decision-making.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-responsible-ai-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: responsibleaidashboard-diabetes-regression-model-debugging
         path: sdk/python/responsible-ai/responsibleaidashboard-diabetes-regression-model-debugging
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'responsible-ai/responsibleaidashboard-diabetes-regression-model-debugging/responsibleaidashboard-diabetes-regression-model-debugging.ipynb'"
-                Summary: |
-                    Notebook 'responsible-ai/responsibleaidashboard-diabetes-regression-model-debugging/responsibleaidashboard-diabetes-regression-model-debugging.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "responsible-ai/responsibleaidashboard-diabetes-regression-model-debugging/responsibleaidashboard-diabetes-regression-model-debugging.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-responsible-ai-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: responsibleaidashboard-housing-classification-model-debugging
         path: sdk/python/responsible-ai/responsibleaidashboard-housing-classification-model-debugging
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'responsible-ai/responsibleaidashboard-housing-classification-model-debugging/responsibleaidashboard-housing-classification-model-debugging.ipynb'"
-                Summary: |
-                    Notebook 'responsible-ai/responsibleaidashboard-housing-classification-model-debugging/responsibleaidashboard-housing-classification-model-debugging.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "responsible-ai/responsibleaidashboard-housing-classification-model-debugging/responsibleaidashboard-housing-classification-model-debugging.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-responsible-ai-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: responsibleaidashboard-housing-decision-making
         path: sdk/python/responsible-ai/responsibleaidashboard-housing-decision-making
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'responsible-ai/responsibleaidashboard-housing-decision-making/responsibleaidashboard-housing-decision-making.ipynb'"
-                Summary: |
-                    Notebook 'responsible-ai/responsibleaidashboard-housing-decision-making/responsibleaidashboard-housing-decision-making.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "responsible-ai/responsibleaidashboard-housing-decision-making/responsibleaidashboard-housing-decision-making.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-responsible-ai-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
@@ -75,22 +75,3 @@ jobs:
       with:
         name: responsibleaidashboard-programmer-regression-model-debugging
         path: sdk/python/responsible-ai/responsibleaidashboard-programmer-regression-model-debugging
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'responsible-ai/responsibleaidashboard-programmer-regression-model-debugging/responsibleaidashboard-programmer-regression-model-debugging.ipynb'"
-                Summary: |
-                    Notebook 'responsible-ai/responsibleaidashboard-programmer-regression-model-debugging/responsibleaidashboard-programmer-regression-model-debugging.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "responsible-ai/responsibleaidashboard-programmer-regression-model-debugging/responsibleaidashboard-programmer-regression-model-debugging.ipynb[${{ github.ref_name }}]"

--- a/.github/workflows/sdk-schedules-job-schedule.yml
+++ b/.github/workflows/sdk-schedules-job-schedule.yml
@@ -73,22 +73,3 @@ jobs:
       with:
         name: job-schedule
         path: sdk/python/schedules
-
-    - name: Send IcM on failure
-      if: ${{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}
-        connector_id: ${{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}
-        certificate: ${{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}
-        private_key: ${{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{ github.ref_name }}' for notebook 'schedules/job-schedule.ipynb'"
-                Summary: |
-                    Notebook 'schedules/job-schedule.ipynb' is failing on branch '${{ github.ref_name }}': ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "schedules/job-schedule.ipynb[${{ github.ref_name }}]"

--- a/sdk/python/readme.py
+++ b/sdk/python/readme.py
@@ -238,26 +238,6 @@ jobs:
     - name: Remove the compute if notebook did not done it properly.
       run: bash "{github_workspace}/infra/remove_computes.sh" {nb_config.get(section=name, option=COMPUTE_NAMES)}\n"""
 
-    workflow_yaml += f"""
-    - name: Send IcM on failure
-      if: ${{{{ failure() && github.ref_type == 'branch' && (github.ref_name == 'main' || contains(github.ref_name, 'release')) }}}}
-      uses: ./.github/actions/generate-icm
-      with:
-        host: ${{{{ secrets.AZUREML_ICM_CONNECTOR_HOST_NAME }}}}
-        connector_id: ${{{{ secrets.AZUREML_ICM_CONNECTOR_CONNECTOR_ID }}}}
-        certificate: ${{{{ secrets.AZUREML_ICM_CONNECTOR_CERTIFICATE }}}}
-        private_key: ${{{{ secrets.AZUREML_ICM_CONNECTOR_PRIVATE_KEY }}}}
-        args: |
-            incident:
-                Title: "[azureml-examples] Notebook validation failed on branch '${{{{ github.ref_name }}}}' for notebook '{posix_notebook}'"
-                Summary: |
-                    Notebook '{posix_notebook}' is failing on branch '${{{{ github.ref_name }}}}': ${{{{ github.server_url }}}}/${{{{ github.repository }}}}/actions/runs/${{{{ github.run_id }}}}
-                Severity: 4
-                RoutingId: "github://azureml-examples"
-                Status: Active
-                Source:
-                    IncidentId: "{posix_notebook}[${{{{ github.ref_name }}}}]"\n"""
-
     workflow_file = os.path.join(
         "..", "..", ".github", "workflows", f"sdk-{classification}-{name}.yml"
     )


### PR DESCRIPTION
# Description

IcM generation for failed workflows leverages a monitor external to github that generates IcMs, so workflows no longer need to manually trigger creation of an IcM

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
