### PR TITLE
Change file type to make definition consistent

### DIFF
--- a/cli/jobs/pipelines-with-components/basics/4b_datastore_datapath_uri/component-file.yml
+++ b/cli/jobs/pipelines-with-components/basics/4b_datastore_datapath_uri/component-file.yml
@@ -7,7 +7,7 @@ version: 1
 
 inputs:
   sample_input_data_file:
-    type: uri_folder
+    type: uri_file
   placeholder:
     type: uri_folder
 outputs:

--- a/cli/jobs/pipelines-with-components/basics/4b_datastore_datapath_uri/component-folder.yml
+++ b/cli/jobs/pipelines-with-components/basics/4b_datastore_datapath_uri/component-folder.yml
@@ -7,7 +7,7 @@ version: 1
 
 inputs:
   sample_input_data:
-    type: mltable
+    type: uri_folder
   sample_input_string:
     type: string
     default: "component_folder"

--- a/cli/jobs/pipelines-with-components/basics/4c_web_url_input/component.yml
+++ b/cli/jobs/pipelines-with-components/basics/4c_web_url_input/component.yml
@@ -7,7 +7,7 @@ version: 1
 
 inputs:
   sample_input_data:
-    type: uri_folder
+    type: uri_file
   sample_input_string:
     type: string
     default: "hello_python_world"


### PR DESCRIPTION
# Description
Some examples in the pipeline yaml files are defining file type without consistency. Although the file type may be overwritten when defining pipelines, these examples may lead to misunderstanding and cause confusion.

# Checklist
1. Changed the file type of the input in _4b_datastore_datapath_uri/component-file.yml_ from _uri_folder_ to _uri_file_, consistent with the input type in _ /4b_datastore_datapath_uri)/pipeline.yml_
2. Changed the file type of the input in _4b_datastore_datapath_uri/component-folder.yml_ from _mltable_ to _uri_folder_, consistent with the input type in _ /4b_datastore_datapath_uri)/pipeline.yml_
3. Changed the file type of the input in _4c_web_url_input/component.yml_ from _uri_folder_ to _uri_file_, consistent with the input type in _ 4c_web_url_input/pipeline.yml_


- [√] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] Pull request includes test coverage for the included changes.
