### PR TITLE
Remove timeouts for AutoMode to reduce potential for confusion

### DIFF
--- a/cli/jobs/automl-standalone-jobs/cli-automl-image-classification-multiclass-task-fridge-items/cli-automl-image-classification-multiclass-task-fridge-items-automode.yml
+++ b/cli/jobs/automl-standalone-jobs/cli-automl-image-classification-multiclass-task-fridge-items/cli-automl-image-classification-multiclass-task-fridge-items-automode.yml
@@ -22,6 +22,5 @@ validation_data:
   type: mltable
 
 limits:
-  timeout_minutes: 60
   max_trials: 10
   max_concurrent_trials: 2

--- a/cli/jobs/automl-standalone-jobs/cli-automl-image-classification-multilabel-task-fridge-items/cli-automl-image-classification-multilabel-task-fridge-items-automode.yml
+++ b/cli/jobs/automl-standalone-jobs/cli-automl-image-classification-multilabel-task-fridge-items/cli-automl-image-classification-multilabel-task-fridge-items-automode.yml
@@ -21,6 +21,5 @@ validation_data:
   type: mltable
 
 limits:
-  timeout_minutes: 60
   max_trials: 10
   max_concurrent_trials: 2

--- a/cli/jobs/automl-standalone-jobs/cli-automl-image-instance-segmentation-task-fridge-items/cli-automl-image-instance-segmentation-task-fridge-items-automode.yml
+++ b/cli/jobs/automl-standalone-jobs/cli-automl-image-instance-segmentation-task-fridge-items/cli-automl-image-instance-segmentation-task-fridge-items-automode.yml
@@ -21,6 +21,5 @@ validation_data:
   type: mltable
 
 limits:
-  timeout_minutes: 60
   max_trials: 10
   max_concurrent_trials: 2

--- a/cli/jobs/automl-standalone-jobs/cli-automl-image-object-detection-task-fridge-items/cli-automl-image-object-detection-task-fridge-items-automode.yml
+++ b/cli/jobs/automl-standalone-jobs/cli-automl-image-object-detection-task-fridge-items/cli-automl-image-object-detection-task-fridge-items-automode.yml
@@ -30,7 +30,6 @@ validation_data:
 
 # <limit_settings>
 limits:
-  timeout_minutes: 60
   max_trials: 10
   max_concurrent_trials: 2
 # </limit_settings>

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
@@ -508,7 +508,7 @@
     "image_classification_job.set_limits(\n",
     "    max_trials=10,\n",
     "    max_concurrent_trials=2,\n",
-    ")\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
@@ -505,7 +505,10 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_classification_job.set_limits(max_trials=5, max_concurrent_trials=2)"
+    "image_classification_job.set_limits(\n",
+    "    max_trials=10,\n",
+    "    max_concurrent_trials=2,\n",
+    ")\n",
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
@@ -505,9 +505,7 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_classification_job.set_limits(\n",
-    "    max_trials=5, max_concurrent_trials=2\n",
-    ")"
+    "image_classification_job.set_limits(max_trials=5, max_concurrent_trials=2)"
    ]
   },
   {
@@ -1395,41 +1393,40 @@
   }
  ],
  "metadata": {
-    "interpreter": {
-     "hash": "da404a94b19d2e6a57be28cbcf6e71fbd41612916c3423bc5e257c11b3d83fa0"
-    },
-    "kernel_info": {
-     "name": "python3-azureml"
-    },
-    "kernelspec": {
-     "display_name": "Python 3.10 - SDK V2",
-     "language": "python",
-     "name": "python310-sdkv2"
-    },
-    "language_info": {
-     "codemirror_mode": {
-      "name": "ipython",
-      "version": 3
-     },
-     "file_extension": ".py",
-     "mimetype": "text/x-python",
-     "name": "python",
-     "nbconvert_exporter": "python",
-     "pygments_lexer": "ipython3",
-     "version": "3.7.10"
-    },
-    "microsoft": {
-     "host": {
-      "AzureML": {
-       "notebookHasBeenCompleted": true
-      }
-     }
-    },
-    "nteract": {
-     "version": "nteract-front-end@1.0.0"
-    }
+  "interpreter": {
+   "hash": "da404a94b19d2e6a57be28cbcf6e71fbd41612916c3423bc5e257c11b3d83fa0"
+  },
+  "kernel_info": {
+   "name": "python3-azureml"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.10 - SDK V2",
+   "language": "python",
+   "name": "python310-sdkv2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
    },
-   "nbformat": 4,
-   "nbformat_minor": 4
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  },
+  "microsoft": {
+   "host": {
+    "AzureML": {
+     "notebookHasBeenCompleted": true
+    }
+   }
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
   }
-  
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
@@ -506,7 +506,7 @@
     ")\n",
     "\n",
     "image_classification_job.set_limits(\n",
-    "    timeout_minutes=60, max_trials=5, max_concurrent_trials=2\n",
+    "    max_trials=5, max_concurrent_trials=2\n",
     ")"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
@@ -498,7 +498,7 @@
     ")\n",
     "\n",
     "image_classification_multilabel_job.set_limits(\n",
-    "    timeout_minutes=60, max_trials=5, max_concurrent_trials=2\n",
+    "    max_trials=5, max_concurrent_trials=2\n",
     ")"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
@@ -497,9 +497,7 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_classification_multilabel_job.set_limits(\n",
-    "    max_trials=5, max_concurrent_trials=2\n",
-    ")"
+    "image_classification_multilabel_job.set_limits(max_trials=5, max_concurrent_trials=2)"
    ]
   },
   {
@@ -1391,38 +1389,37 @@
   }
  ],
  "metadata": {
-    "kernel_info": {
-     "name": "python3-azureml"
-    },
-    "kernelspec": {
-     "display_name": "Python 3.10 - SDK V2",
-     "language": "python",
-     "name": "python310-sdkv2"
-    },
-    "language_info": {
-     "codemirror_mode": {
-      "name": "ipython",
-      "version": 3
-     },
-     "file_extension": ".py",
-     "mimetype": "text/x-python",
-     "name": "python",
-     "nbconvert_exporter": "python",
-     "pygments_lexer": "ipython3",
-     "version": "3.8.12"
-    },
-    "microsoft": {
-     "host": {
-      "AzureML": {
-       "notebookHasBeenCompleted": true
-      }
-     }
-    },
-    "nteract": {
-     "version": "nteract-front-end@1.0.0"
-    }
+  "kernel_info": {
+   "name": "python3-azureml"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.10 - SDK V2",
+   "language": "python",
+   "name": "python310-sdkv2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
    },
-   "nbformat": 4,
-   "nbformat_minor": 4
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "microsoft": {
+   "host": {
+    "AzureML": {
+     "notebookHasBeenCompleted": true
+    }
+   }
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
   }
-  
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
@@ -497,7 +497,10 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_classification_multilabel_job.set_limits(max_trials=5, max_concurrent_trials=2)"
+    "image_classification_multilabel_job.set_limits(\n",
+    "    max_trials=10,\n",
+    "    max_concurrent_trials=2,\n",
+    ")\n",
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
@@ -500,7 +500,7 @@
     "image_classification_multilabel_job.set_limits(\n",
     "    max_trials=10,\n",
     "    max_concurrent_trials=2,\n",
-    ")\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -475,9 +475,7 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_instance_segmentation_job.set_limits(\n",
-    "    max_trials=5, max_concurrent_trials=2\n",
-    ")"
+    "image_instance_segmentation_job.set_limits(max_trials=5, max_concurrent_trials=2)"
    ]
   },
   {
@@ -1290,37 +1288,37 @@
   }
  ],
  "metadata": {
-    "kernel_info": {
-     "name": "python3-azureml"
-    },
-    "kernelspec": {
-     "display_name": "Python 3.10 - SDK V2",
-     "language": "python",
-     "name": "python310-sdkv2"
-    },
-    "language_info": {
-     "codemirror_mode": {
-      "name": "ipython",
-      "version": 3
-     },
-     "file_extension": ".py",
-     "mimetype": "text/x-python",
-     "name": "python",
-     "nbconvert_exporter": "python",
-     "pygments_lexer": "ipython3",
-     "version": "3.7.10"
-    },
-    "microsoft": {
-     "host": {
-      "AzureML": {
-       "notebookHasBeenCompleted": true
-      }
-     }
-    },
-    "nteract": {
-     "version": "nteract-front-end@1.0.0"
-    }
+  "kernel_info": {
+   "name": "python3-azureml"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.10 - SDK V2",
+   "language": "python",
+   "name": "python310-sdkv2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
    },
-   "nbformat": 4,
-   "nbformat_minor": 4
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  },
+  "microsoft": {
+   "host": {
+    "AzureML": {
+     "notebookHasBeenCompleted": true
+    }
+   }
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
   }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -475,7 +475,10 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_instance_segmentation_job.set_limits(max_trials=5, max_concurrent_trials=2)"
+    "image_instance_segmentation_job.set_limits(\n",
+    "    max_trials=10,\n",
+    "    max_concurrent_trials=2,\n",
+    ")\n",
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -476,7 +476,7 @@
     ")\n",
     "\n",
     "image_instance_segmentation_job.set_limits(\n",
-    "    timeout_minutes=60, max_trials=5, max_concurrent_trials=2\n",
+    "    max_trials=5, max_concurrent_trials=2\n",
     ")"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -478,7 +478,7 @@
     "image_instance_segmentation_job.set_limits(\n",
     "    max_trials=10,\n",
     "    max_concurrent_trials=2,\n",
-    ")\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -559,7 +559,7 @@
     ")\n",
     "\n",
     "image_object_detection_job.set_limits(\n",
-    "    timeout_minutes=60, max_trials=5, max_concurrent_trials=2\n",
+    "    max_trials=5, max_concurrent_trials=2\n",
     ")"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -558,9 +558,7 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_object_detection_job.set_limits(\n",
-    "    max_trials=5, max_concurrent_trials=2\n",
-    ")"
+    "image_object_detection_job.set_limits(max_trials=5, max_concurrent_trials=2)"
    ]
   },
   {
@@ -1435,40 +1433,40 @@
   }
  ],
  "metadata": {
-    "interpreter": {
-     "hash": "c436929fd2d0a15e8f5a4bf2b00fe0013508b12c8f1f7fa176c1f6c61998c0e5"
-    },
-    "kernel_info": {
-     "name": "python3-azureml"
-    },
-    "kernelspec": {
-     "display_name": "Python 3.10 - SDK V2",
-     "language": "python",
-     "name": "python310-sdkv2"
-    },
-    "language_info": {
-     "codemirror_mode": {
-      "name": "ipython",
-      "version": 3
-     },
-     "file_extension": ".py",
-     "mimetype": "text/x-python",
-     "name": "python",
-     "nbconvert_exporter": "python",
-     "pygments_lexer": "ipython3",
-     "version": "3.8.13"
-    },
-    "microsoft": {
-     "host": {
-      "AzureML": {
-       "notebookHasBeenCompleted": true
-      }
-     }
-    },
-    "nteract": {
-     "version": "nteract-front-end@1.0.0"
-    }
+  "interpreter": {
+   "hash": "c436929fd2d0a15e8f5a4bf2b00fe0013508b12c8f1f7fa176c1f6c61998c0e5"
+  },
+  "kernel_info": {
+   "name": "python3-azureml"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.10 - SDK V2",
+   "language": "python",
+   "name": "python310-sdkv2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
    },
-   "nbformat": 4,
-   "nbformat_minor": 4
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "microsoft": {
+   "host": {
+    "AzureML": {
+     "notebookHasBeenCompleted": true
+    }
+   }
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
   }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -561,7 +561,7 @@
     "image_object_detection_job.set_limits(\n",
     "    max_trials=10,\n",
     "    max_concurrent_trials=2,\n",
-    ")\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -558,7 +558,10 @@
     "    tags={\"my_custom_tag\": \"My custom value\"},\n",
     ")\n",
     "\n",
-    "image_object_detection_job.set_limits(max_trials=5, max_concurrent_trials=2)"
+    "image_object_detection_job.set_limits(\n",
+    "    max_trials=10,\n",
+    "    max_concurrent_trials=2,\n",
+    ")\n",
    ]
   },
   {


### PR DESCRIPTION
# Description
Remove the timeout values in AutoMode job specifications to prevent users from making mistakes by copy-pasting example code. Short timeouts like those in the examples can interfere with this new feature.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
