### PR TITLE
Avoid warning in Many-Models Notebook

### DIFF
--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
@@ -368,7 +368,6 @@
     "\n",
     "forecasting_parameters = ForecastingParameters(\n",
     "    time_column_name=TIME_COLNAME,\n",
-    "    drop_column_names=\"Revenue\",\n",
     "    forecast_horizon=6,\n",
     "    time_series_id_column_names=partition_column_names,\n",
     "    cv_step_size=\"auto\",\n",

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/auto-ml-forecasting-many-models.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/auto-ml-forecasting-many-models.ipynb
@@ -470,7 +470,7 @@
     "\n",
     "> Note that we only support partitioned FileDataset and TabularDataset without partition when using such output as input.\n",
     "\n",
-    "> Note that we **drop column** \"Revenue\" from the dataset in this step as this is not relevant for forecasting with the dataset used in this example. **Please modify the logic based on your data**."
+    "> Note that we **drop column** \"Revenue\" from the dataset in this step to avoid information leak as \"Quantity\" = \"Revenue\" / \"Price\". **Please modify the logic based on your data**."
    ]
   },
   {

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/auto-ml-forecasting-many-models.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/auto-ml-forecasting-many-models.ipynb
@@ -433,7 +433,6 @@
     "\n",
     "forecasting_parameters = ForecastingParameters(\n",
     "    time_column_name=\"WeekStarting\",\n",
-    "    drop_column_names=\"Revenue\",\n",
     "    forecast_horizon=6,\n",
     "    time_series_id_column_names=partition_column_names,\n",
     "    cv_step_size=\"auto\",\n",
@@ -469,7 +468,9 @@
     "\n",
     "Reuse of previous results (``allow_reuse``) is key when using pipelines in a collaborative environment since eliminating unnecessary reruns offers agility. Reuse is the default behavior when the ``script_name``, ``inputs``, and the parameters of a step remain the same. When reuse is allowed, results from the previous run are immediately sent to the next step. If ``allow_reuse`` is set to False, a new run will always be generated for this step during pipeline execution.\n",
     "\n",
-    "> Note that we only support partitioned FileDataset and TabularDataset without partition when using such output as input."
+    "> Note that we only support partitioned FileDataset and TabularDataset without partition when using such output as input.\n",
+    "\n",
+    "> Note that we **drop column** \"Revenue\" from the dataset in this step as this is not relevant for forecasting with the dataset used in this example. **Please modify the logic based on your data**."
    ]
   },
   {

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/scripts/data_preprocessing_tabular.py
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/scripts/data_preprocessing_tabular.py
@@ -11,6 +11,12 @@ def main(args):
     dataset = run_context.input_datasets["train_10_models"]
     df = dataset.to_pandas_dataframe()
 
+    # Drop the column "Revenue" from the dataset
+    # Please remove if this is not required
+    drop_column_name = "Revenue"
+    if drop_column_name in df.columns:
+        df.drop(drop_column_name, axis=1, inplace=True)
+
     # Apply any data pre-processing techniques here
 
     df.to_parquet(output / "data_prepared_result.parquet", compression=None)

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/scripts/data_preprocessing_tabular.py
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-many-models/scripts/data_preprocessing_tabular.py
@@ -11,8 +11,8 @@ def main(args):
     dataset = run_context.input_datasets["train_10_models"]
     df = dataset.to_pandas_dataframe()
 
-    # Drop the column "Revenue" from the dataset
-    # Please remove if this is not required
+    # Drop the column "Revenue" from the dataset to avoid information leak as
+    # "Quantity" = "Revenue" / "Price". Please modify the logic based on your data.
     drop_column_name = "Revenue"
     if drop_column_name in df.columns:
         df.drop(drop_column_name, axis=1, inplace=True)


### PR DESCRIPTION
# Description

This PR contains three changes:
- Removal of parameter ``drop_column_names`` from Many Models Backtest Notebook as we don't have this column in the dataset.
- Removal of parameter ``drop_column_names`` from Many Models Notebook.
- Logic to drop "Revenue" column in the data_preprocessing step for Many Models Notebook.

Validations performed:
- Manually verified that the warning is no longer appearing in both the notebooks.
- Successfully ran the Many Models Notebook to verify the logic for dropping column.
- GitHub workflows completed successfully.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
