### PR TITLE
adjust multilabel notebook to adapt prediction format change

### DIFF
--- a/v1/python-sdk/tutorials/automl-with-azureml/automl-nlp-multilabel/automl-nlp-text-classification-multilabel.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/automl-nlp-multilabel/automl-nlp-text-classification-multilabel.ipynb
@@ -460,10 +460,7 @@
    "outputs": [],
    "source": [
     "test_data_df = test_dataset.to_pandas_dataframe()\n",
-    "test_set_predictions_df = pd.read_csv(\"preds_multilabel.csv\")\n",
-    "test_set_predictions_df[\"label_confidence\"] = test_set_predictions_df[\n",
-    "    \"label_confidence\"\n",
-    "].apply(lambda x: [float(num) for num in x.split(\",\")])"
+    "test_set_predictions_df = pd.read_csv(\"preds_multilabel.csv\")"
    ]
   },
   {
@@ -511,10 +508,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_pred_probs = []\n",
-    "for i in range(test_set_predictions_df.shape[0]):\n",
-    "    test_pred_probs.append(test_set_predictions_df.loc[i, \"label_confidence\"])\n",
-    "test_pred_probs = np.array(test_pred_probs)"
+    "test_pred_probs = test_set_predictions_df.to_numpy()"
    ]
   },
   {
@@ -576,11 +570,12 @@
     "    y_true = []\n",
     "    y_pred = []\n",
     "\n",
+    "    pred_df = pred_df.to_numpy()\n",
     "    for row in range(test_df.shape[0]):\n",
     "        true_labels = y_transformer.transform(\n",
     "            [ast.literal_eval(test_df.loc[row, label_col])]\n",
     "        ).toarray()[0]\n",
-    "        pred_labels = pred_df.loc[row, \"label_confidence\"]\n",
+    "        pred_labels = pred_df[row]\n",
     "        for ind, (label, prob) in enumerate(zip(true_labels, pred_labels)):\n",
     "            predict_positive = prob >= threshold\n",
     "            if label or predict_positive:\n",


### PR DESCRIPTION
data format change

# Description
the probability of each label in prediction in NLP multilabel task has changed, causing errors in previous result evaluation. In this PR, I adjust the offline evaluation code adapt to the format change.

# Checklist


- [X] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [X] Pull request includes test coverage for the included changes.
