### PR TITLE
Move from loading JSON to CSV during inference.

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -719,7 +719,7 @@
    "metadata": {},
    "source": [
     "### Download the prediction result for metrics calculation\n",
-    "The output of prediction is saved in JSON format. You can use it to calculate test set metrics and plot predictions and actuals over time."
+    "The output of prediction is saved in CSV format. You can use it to calculate test set metrics and plot predictions and actuals over time."
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -737,7 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -737,7 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -631,7 +631,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_file = \"forecast.json\"\n",
+    "output_file = \"forecast.csv\"\n",
     "batch_deployment = BatchDeployment(\n",
     "    name=\"non-mlflow-deployment\",\n",
     "    description=\"this is a sample non-mlflow deployment\",\n",
@@ -651,6 +651,8 @@
     "    output_file_name=output_file,\n",
     "    retry_settings=BatchRetrySettings(max_retries=3, timeout=30),\n",
     "    logging_level=\"info\",\n",
+    "    properties={\"include_output_header\": \"true\"},\n",
+    "    tags={\"include_output_header\": \"true\"},\n",
     ")"
    ]
   },
@@ -735,7 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_json(output_file, orient=\"table\")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/helpers/forecasting_script.py
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/helpers/forecasting_script.py
@@ -52,9 +52,7 @@ def run(mini_batch):
         # drop rows where prediction or actuals are nan happens because of missing actuals or at edges of time due to lags/rolling windows]
         X_rf.dropna(inplace=True)
         print(f"The predictions have {X_rf.shape[0]} rows and {X_rf.shape[1]} columns.")
-        # Save data as a json string as otherwise we will loose the header.
-        json_string = X_rf.to_json(orient="table")
 
-        resultList.append(json_string)
+        resultList.append(X_rf)
 
-    return resultList
+    return pd.concat(resultList, sort=False, ignore_index=True)

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/helpers/parallel_run_step.settings.json
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/helpers/parallel_run_step.settings.json
@@ -1,0 +1,1 @@
+{"append_row": {"pandas.DataFrame.to_csv": {"sep": ","}}}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
@@ -898,6 +898,8 @@
     "    output_file_name=output_file,\n",
     "    retry_settings=BatchRetrySettings(max_retries=3, timeout=30),\n",
     "    logging_level=\"info\",\n",
+    "    properties={\"include_output_header\": \"true\"},\n",
+    "    tags={\"include_output_header\": \"true\"},\n",
     ")"
    ]
   },
@@ -987,7 +989,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_json(output_file, orient=\"table\")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
@@ -971,7 +971,7 @@
    "metadata": {},
    "source": [
     "### Download the prediction result for metrics calculation\n",
-    "The output of forecast output is saved in JSON format. You can use it to calculate test set metrics and plot predictions and actuals over time."
+    "The output of forecast output is saved in CSV format. You can use it to calculate test set metrics and plot predictions and actuals over time."
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
@@ -989,7 +989,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
@@ -878,7 +878,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_file = \"forecast.json\"\n",
+    "output_file = \"forecast.csv\"\n",
     "batch_deployment = BatchDeployment(\n",
     "    name=\"oj-non-mlflow-deployment\",\n",
     "    description=\"this is a sample non-mlflow deployment\",\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
@@ -989,7 +989,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/forecast/forecasting_script.py
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/forecast/forecasting_script.py
@@ -58,9 +58,7 @@ def run(mini_batch):
         print(
             f"The predictions have {clean.shape[0]} rows and {clean.shape[1]} columns."
         )
-        # Save data as a json string as otherwise we will loose the header.
-        json_string = clean.to_json(orient="table")
 
-        resultList.append(json_string)
+        resultList.append(clean)
 
-    return resultList
+    return pd.concat(resultList, sort=False, ignore_index=True)

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/forecast/parallel_run_step.settings.json
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/forecast/parallel_run_step.settings.json
@@ -1,0 +1,1 @@
+{"append_row": {"pandas.DataFrame.to_csv": {"sep": ","}}}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -859,7 +859,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -752,7 +752,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_file = \"rolling_forecast.json\"\n",
+    "output_file = \"rolling_forecast.csv\"\n",
     "batch_deployment = BatchDeployment(\n",
     "    name=\"non-mlflow-deployment\",\n",
     "    description=\"this is a sample non-mlflow deployment\",\n",
@@ -841,7 +841,7 @@
    "metadata": {},
    "source": [
     "### Download the prediction result for metrics calculation\n",
-    "The output of forecast output is saved in JSON format. You can use it to calculate test set metrics and plot predictions and actuals over time."
+    "The output of forecast output is saved in CSV format. You can use it to calculate test set metrics and plot predictions and actuals over time."
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -772,6 +772,8 @@
     "    output_file_name=output_file,\n",
     "    retry_settings=BatchRetrySettings(max_retries=3, timeout=30),\n",
     "    logging_level=\"info\",\n",
+    "    properties={\"include_output_header\": \"true\"},\n",
+    "    tags={\"include_output_header\": \"true\"},\n",
     ")"
    ]
   },
@@ -857,7 +859,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_json(output_file, orient=\"table\")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -859,7 +859,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/forecast/parallel_run_step.settings.json
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/forecast/parallel_run_step.settings.json
@@ -1,0 +1,1 @@
+{"append_row": {"pandas.DataFrame.to_csv": {"sep": ","}}}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/forecast/rolling_script.py
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/forecast/rolling_script.py
@@ -49,9 +49,7 @@ def run(mini_batch):
         # drop rows where prediction or actuals are nan happens because of missing actuals or at edges of time due to lags/rolling windows]
         X_rf.dropna(inplace=True)
         print(f"The predictions have {X_rf.shape[0]} rows and {X_rf.shape[1]} columns.")
-        # Save data as a json string as otherwise we will loose the header.
-        json_string = X_rf.to_json(orient="table")
 
-        resultList.append(json_string)
+        resultList.append(X_rf)
 
-    return resultList
+    return pd.concat(resultList, sort=False, ignore_index=True)

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
@@ -847,7 +847,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
@@ -847,7 +847,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name], sep=\" \")\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
@@ -756,6 +756,8 @@
     "    output_file_name=output_file,\n",
     "    retry_settings=BatchRetrySettings(max_retries=3, timeout=30),\n",
     "    logging_level=\"info\",\n",
+    "    properties={\"include_output_header\": \"true\"},\n",
+    "    tags={\"include_output_header\": \"true\"},\n",
     ")"
    ]
   },
@@ -845,7 +847,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcst_df = pd.read_json(output_file, orient=\"table\")\n",
+    "fcst_df = pd.read_csv(output_file, parse_dates=[time_column_name])\n",
     "fcst_df.head()"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
@@ -736,7 +736,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_file = \"forecast.json\"\n",
+    "output_file = \"forecast.csv\"\n",
     "batch_deployment = BatchDeployment(\n",
     "    name=\"non-mlflow-deployment\",\n",
     "    description=\"this is a sample non-mlflow deployment\",\n",
@@ -829,7 +829,7 @@
    "metadata": {},
    "source": [
     "### Download the prediction result for metrics calculation\n",
-    "The output of forecast output is saved in JSON format. You can use it to calculate test set metrics and plot predictions and actuals over time."
+    "The output of forecast output is saved in CSV format. You can use it to calculate test set metrics and plot predictions and actuals over time."
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/forecast/forecasting_script.py
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/forecast/forecasting_script.py
@@ -57,9 +57,7 @@ def run(mini_batch):
         print(
             f"The predictions have {clean.shape[0]} rows and {clean.shape[1]} columns."
         )
-        # Save data as a json string as otherwise we will loose the header.
-        json_string = clean.to_json(orient="table")
 
-        resultList.append(json_string)
+        resultList.append(clean)
 
-    return resultList
+    return pd.concat(resultList, sort=False, ignore_index=True)

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/forecast/parallel_run_step.settings.json
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/forecast/parallel_run_step.settings.json
@@ -1,0 +1,1 @@
+{"append_row": {"pandas.DataFrame.to_csv": {"sep": ","}}}


### PR DESCRIPTION
# Description
Recent changes in the BatchEndpoint caused downloaded JSON file to contain newline characters, which resulted in errors while trying to parse inference iutputs. Meanwhile another change allowd to download the CSV file directly.
In this PR we are moving from loading JSON to CSV.
See the work item 2122934.

# Checklist


- [X] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
