### PR TITLE
Fix CLI failing sample "image_classification_with_densenet"

### DIFF
--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/image_classification/training.py
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/image_classification/training.py
@@ -623,7 +623,7 @@ def train_loop(
         ts = str(time.time())
         # logdir = os.path.expanduser('~/tensorboard/{}/logs/'.format(os.environ['DLTS_JOB_ID']) + ts)
         logdir = os.path.expanduser(
-            "~/tensorboard/{}/logs/".format(os.environ["AZ_BATCH_JOB_ID"]) + ts
+            "~/tensorboard/{}/logs/".format(os.environ["AZUREML_RUN_ID"]) + ts
         )
         print("tensorboard at ", logdir)
         if not os.path.exists(logdir):


### PR DESCRIPTION
# Description

Fix CLI failing sample "image_classification_with_densenet", replace `AZ_BATCH_JOB_ID` with `AZUREML_RUN_ID` to avoid key error.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
