### PR TITLE
Update max trials in cli-automl-classification-task-bankmarketing.yml

### DIFF
--- a/cli/jobs/automl-standalone-jobs/cli-automl-classification-task-bankmarketing/cli-automl-classification-task-bankmarketing.yml
+++ b/cli/jobs/automl-standalone-jobs/cli-automl-classification-task-bankmarketing/cli-automl-classification-task-bankmarketing.yml
@@ -30,7 +30,7 @@ test_data:
 limits:
   timeout_minutes: 180
   max_trials: 40
-  max_concurrent_trials: 5
+  max_concurrent_trials: 4
   trial_timeout_minutes: 20
   enable_early_termination: true
   exit_score: 0.92


### PR DESCRIPTION
# Description
The max nodes on the compute cluster is set to 4 nodes whereas the max concurrent trials count is set to 5. Updating the max trials for this job to 4

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
