### PR TITLE
Handle groupby when no tsid column

### DIFF
--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
@@ -761,7 +761,7 @@
    "automated-machine-learning"
   ],
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('azure_automl_1_47')",
+   "display_name": "Python 3.8.5 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -775,11 +775,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.5"
   },
   "vscode": {
    "interpreter": {
-    "hash": "5b0ceeab9d24fd744223c252d84eda58b977e1bd6e134933205351358833920c"
+    "hash": "6bd77c88278e012ef31757c15997a7bea8c943977c43d6909403c00ae11d43ca"
    }
   }
  },

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-backtest-many-models/auto-ml-forecasting-backtest-many-models.ipynb
@@ -195,10 +195,9 @@
     "\n",
     "dfs_train = []\n",
     "dfs_test = []\n",
-    "for ts_id, df_one in X.groupby(TIME_SERIES_ID_COLNAME):\n",
     "\n",
+    "def create_test_train(df_one):\n",
     "    data_end = df_one[TIME_COLNAME].max()\n",
-    "\n",
     "    for i in range(NUMBER_OF_BACKTESTS):\n",
     "        train_cutoff_date = data_end - to_offset(offset_type)\n",
     "        df_one = df_one.copy()\n",
@@ -211,6 +210,12 @@
     "        data_end = train[TIME_COLNAME].max()\n",
     "        dfs_train.append(train)\n",
     "        dfs_test.append(test)\n",
+    "\n",
+    "if TIME_SERIES_ID_COLNAME:\n",
+    "    for ts_id, df_one in X.groupby(TIME_SERIES_ID_COLNAME):\n",
+    "        create_test_train(df_one)\n",
+    "else:\n",
+    "    create_test_train(X)\n",
     "\n",
     "X_train = pd.concat(dfs_train, sort=False, ignore_index=True)\n",
     "X_test = pd.concat(dfs_test, sort=False, ignore_index=True)"
@@ -364,7 +369,10 @@
     "from azureml.automl.core.forecasting_parameters import ForecastingParameters\n",
     "from azureml.train.automl.automlconfig import AutoMLConfig\n",
     "\n",
-    "partition_column_names = [TIME_SERIES_ID_COLNAME, \"backtest_iteration\"]\n",
+    "if TIME_SERIES_ID_COLNAME:\n",
+    "    partition_column_names = [TIME_SERIES_ID_COLNAME, \"backtest_iteration\"]\n",
+    "else:\n",
+    "    partition_column_names = [\"backtest_iteration\"]\n",
     "\n",
     "forecasting_parameters = ForecastingParameters(\n",
     "    time_column_name=TIME_COLNAME,\n",
@@ -753,7 +761,7 @@
    "automated-machine-learning"
   ],
   "kernelspec": {
-   "display_name": "Python 3.8.5 ('base')",
+   "display_name": "Python 3.8.13 ('azure_automl_1_47')",
    "language": "python",
    "name": "python3"
   },
@@ -767,11 +775,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {
-    "hash": "6bd77c88278e012ef31757c15997a7bea8c943977c43d6909403c00ae11d43ca"
+    "hash": "5b0ceeab9d24fd744223c252d84eda58b977e1bd6e134933205351358833920c"
    }
   }
  },


### PR DESCRIPTION
# Description

backtest-many-models notebook fails when there's no tsid columns because we always try to group by tsid column. This PR introduces a check to verify if the end user is supplying tsid column or not and then generate the test and train dataset accordingly.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
