### PR TITLE
Removing step to archive anonymous model on triton deployment

### DIFF
--- a/sdk/python/endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb
+++ b/sdk/python/endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb
@@ -568,22 +568,6 @@
    "source": [
     "ml_client.online_endpoints.begin_delete(name=endpoint_name)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7.3 Archive the model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ml_client.models.archive(name=model_name, version=model_version)"
-   ]
   }
  ],
  "metadata": {

--- a/sdk/python/endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb
+++ b/sdk/python/endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb
@@ -535,27 +535,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 7.1 Get model name and version"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "deployment = ml_client.online_deployments.get(name=\"blue\", endpoint_name=endpoint_name)\n",
-    "\n",
-    "model_uri = deployment.model.split(\"/\")\n",
-    "model_name = model_uri[-3]\n",
-    "model_version = model_uri[-1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7.2 Delete the endpoint"
+    "### 7.1 Delete the endpoint and underlying deployment"
    ]
   },
   {

--- a/sdk/python/endpoints/online/triton/single-model/online-endpoints-triton.ipynb
+++ b/sdk/python/endpoints/online/triton/single-model/online-endpoints-triton.ipynb
@@ -455,22 +455,6 @@
    "source": [
     "ml_client.online_endpoints.begin_delete(name=endpoint_name)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 6.3 Archive the model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ml_client.models.archive(name=model_name, version=model_version)"
-   ]
   }
  ],
  "metadata": {

--- a/sdk/python/endpoints/online/triton/single-model/online-endpoints-triton.ipynb
+++ b/sdk/python/endpoints/online/triton/single-model/online-endpoints-triton.ipynb
@@ -422,27 +422,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 6.1 Get model name and version"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "deployment = ml_client.online_deployments.get(name=\"blue\", endpoint_name=endpoint_name)\n",
-    "\n",
-    "model_uri = deployment.model.split(\"/\")\n",
-    "model_name = model_uri[-3]\n",
-    "model_version = model_uri[-1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 6.2 Delete the endpoint"
+    "### 6.1 Delete the endpoint and underlying deployment"
    ]
   },
   {


### PR DESCRIPTION
# Description
There is no need to archive anonymous/unregistered models since these are registered by the system and they shouldn't show up on listing models.

Furthermore, with stages, this stage transition will be disallowed and will trigger an error.

# Checklist


- [X] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] Pull request includes test coverage for the included changes.
