### PR TITLE
Fix the "Value too great for base" in init script.

### DIFF
--- a/infra/init_environment.sh
+++ b/infra/init_environment.sh
@@ -41,9 +41,11 @@ export SLEEP_SECONDS=20
 
 # let "DATE_ONLY=`date +'%y%m%d'`"
 # let "DATE_ONLY=$(date +'%y%m%U')"
-let "DATE_ONLY=$(date -d '+2 days' +'%y%m')"
-let "REGISTRY_TODAY=$(date +'%m%d')"
-let "REGISTRY_TOMORROW=$(date -d '+1 days' +'%m%d')"
+# Add 10# to the front of variables to avoid the "Value too great for base" error when value has leading zeros.
+# Ref: https://stackoverflow.com/questions/21049822/value-too-great-for-base-error-token-is-09
+let "DATE_ONLY=10#$(date -d '+2 days' +'%y%m')"
+let "REGISTRY_TODAY=10#$(date +'%m%d')"
+let "REGISTRY_TOMORROW=10#$(date -d '+1 days' +'%m%d')"
 
 
 export LOCATION="East US"


### PR DESCRIPTION
# Description
This PR fixes the the "Value too great for base" in `init_environment.sh`.
Root cause for the issue values with starting 0 will be treat as octal in bash.
Ref: https://stackoverflow.com/questions/21049822/value-too-great-for-base-error-token-is-09

![image](https://user-images.githubusercontent.com/7776147/211243134-cb9dc464-6caf-4683-8bc3-e30953f76cb4.png)


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] Pull request includes test coverage for the included changes.
