### PR TITLE
Lock jupyter-client version to 7.4.9

### DIFF
--- a/sdk/python/dev-requirements.txt
+++ b/sdk/python/dev-requirements.txt
@@ -9,3 +9,4 @@ tensorflow
 tensorflow-hub
 transformers
 keras==2.9
+jupyter-client==7.4.9


### PR DESCRIPTION
# Description

It seems that new `jupyter-client` public version (8.0.1, [released](https://pypi.org/project/jupyter-client/#history) on Jan 27) has broken lots of GitHub Actions, lock its version to 7.4.9 to see if it works.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
