### PR TITLE
feat: remove reference to deprecated json schema

### DIFF
--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/apply_image_transformation/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/apply_image_transformation/entry.spec.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/CommandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: microsoftsamples_apply_image_transformation

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/convert_to_image_directory/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/convert_to_image_directory/entry.spec.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/CommandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: microsoftsamples_convert_to_image_directory

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/entry.spec.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: train_image_classification

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/init_image_transformation/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/init_image_transformation/entry.spec.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/CommandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: microsoftsamples_init_image_transformation

--- a/sdk/dotnet/AzureML-Samples-CSharp/Assets/Component/ComponentOperations.cs
+++ b/sdk/dotnet/AzureML-Samples-CSharp/Assets/Component/ComponentOperations.cs
@@ -37,7 +37,7 @@ internal class ComponentOperations
         ComponentContainerResource componentContainerResource = armClient.GetComponentContainerResource(id);
 
         JObject jsonObject = JObject.Parse(@"{
-  '$schema': 'https://azuremlschemas.azureedge.net/development/commandComponent.schema.json',
+  '$schema': 'https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json',
   'name': '" + componentName + @"',
   'type': 'command',
   'version': '" + version + @"',
@@ -119,7 +119,7 @@ internal class ComponentOperations
         ComponentContainerResource componentContainerResource = armClient.GetComponentContainerResource(id);
 
         JObject jsonObject = JObject.Parse(@"{
-  '$schema': 'https://azuremlschemas.azureedge.net/development/commandComponent.schema.json',
+  '$schema': 'https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json',
   'name': '" + componentName + @"',
   'type': 'command',
   'version': '" + version + @"',

--- a/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/apply_image_transformation/apply_image_transformation.yaml
+++ b/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/apply_image_transformation/apply_image_transformation.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: microsoftsamples_apply_image_transformation

--- a/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/convert_to_image_directory/convert_to_image_directory.yaml
+++ b/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/convert_to_image_directory/convert_to_image_directory.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: microsoftsamples_convert_to_image_directory

--- a/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/entry.spec.yaml
+++ b/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/entry.spec.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: train_image_classification

--- a/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/init_image_transformation/init_image_transformation.yaml
+++ b/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/init_image_transformation/init_image_transformation.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
 name: microsoftsamples_init_image_transformation


### PR DESCRIPTION
# Description

Use official json schema link to replace deprecated json schema links in current samples:
https://azuremlschemas.azureedge.net/development/CommandComponent.schema.json
=>
https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
