### PR TITLE
RAI housing decision making notebook: Change metrics to regression metrics

### DIFF
--- a/sdk/python/responsible-ai/responsibleaidashboard-housing-decision-making/responsibleaidashboard-housing-decision-making.ipynb
+++ b/sdk/python/responsible-ai/responsibleaidashboard-housing-decision-making/responsibleaidashboard-housing-decision-making.ipynb
@@ -803,8 +803,8 @@
    "source": [
     "## Score card generation config\n",
     "For score card generation, we need some additional configuration in a separate json file. Here we configure the following model performance metrics for reporting:\n",
-    "- accuracy\n",
-    "- precision"
+    "- mean absolute error\n",
+    "- mean squared error"
    ]
   },
   {
@@ -822,7 +822,7 @@
     "        \"ModelType\": \"Regression\",\n",
     "        \"ModelSummary\": \"<model summary>\",\n",
     "    },\n",
-    "    \"Metrics\": {\"accuracy_score\": {\"threshold\": \">=0.7\"}, \"precision_score\": {}},\n",
+    "    \"Metrics\": {\"mean_squared_error\": {}, \"mean_absolute_error\": {}},\n",
     "}\n",
     "\n",
     "score_card_config_filename = \"rai_housing_decision_score_card_config.json\"\n",


### PR DESCRIPTION
# Description

Duplicate of #2074 but this time with a branch from this repo.

So far, the scorecard metrics were classification metrics leading to a validation error during execution. Changing to regression metrics fixes the problem.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
