### PR TITLE
Fix broken cli sample after `cli/endpoints/online/mlflow` rename

### DIFF
--- a/cli/deploy-custom-container-mlflow-multideployment-scikit.sh
+++ b/cli/deploy-custom-container-mlflow-multideployment-scikit.sh
@@ -14,7 +14,7 @@ export ACR_NAME=$(az ml workspace show --query container_registry -o tsv | cut -
 # <initialize_build_context>
 export PARENT_PATH=endpoints/online/custom-container/mlflow/multideployment-scikit/
 export BASE_PATH="$PARENT_PATH/mlflow_context"
-export ASSET_PATH=endpoints/online/mlflow
+export ASSET_PATH=endpoints/online/ncd
 rm -rf $BASE_PATH && mkdir $BASE_PATH
 # </initialize_build_context> 
 


### PR DESCRIPTION
# Description

This PR fixes the `cli-scripts-deploy-custom-container-mlflow-multideployment-scikit` which was broken after the rename of `cli/endpoints/online/mlflow` -> `cli/endpoints/online/ncd` in #2069

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
