### PR TITLE
Change configuration notebook links for automl forecasting notebooks

### DIFF
--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -723,7 +723,7 @@
   "friendly_name": "Forecasting BikeShare Demand",
   "index_order": 1,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -737,7 +737,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.5"
   },
   "mimetype": "text/x-python",
   "name": "python",


### PR DESCRIPTION
# Description
The links to the config notebook are broken for all forecasting notebooks.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
