### PR TITLE
Update config notebook links for the forecasting notebooks

### DIFF
--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "AutoML highlights here include built-in holiday featurization, accessing engineered feature names, and working with the `forecast` function. Please also look at the additional forecasting notebooks, which document lagging, rolling windows, forecast quantiles, other ways to use the forecast function, and forecaster deployment.\n",
     "\n",
-    "Make sure you have executed the [configuration notebook](../../../configuration.ipynb) before running this notebook.\n",
+    "Make sure you have executed the [configuration notebook](https://github.com/Azure/MachineLearningNotebooks/blob/master/configuration.ipynb) before running this notebook.\n",
     "\n",
     "Notebook synopsis:\n",
     "1. Creating an Experiment in an existing Workspace\n",

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
@@ -767,7 +767,7 @@
    "automated-machine-learning"
   ],
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.5 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -790,5 +790,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-energy-demand/auto-ml-forecasting-energy-demand.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "In this example we use the associated New York City energy demand dataset to showcase how you can use AutoML for a simple forecasting problem and explore the results. The goal is predict the energy demand for the next 48 hours based on historic time-series data.\n",
     "\n",
-    "If you are using an Azure Machine Learning Compute Instance, you are all set. Otherwise, go through the [configuration notebook](../../../configuration.ipynb) first, if you haven't already, to establish your connection to the AzureML Workspace.\n",
+    "If you are using an Azure Machine Learning Compute Instance, you are all set. Otherwise, go through the [configuration notebook](https://github.com/Azure/MachineLearningNotebooks/blob/master/configuration.ipynb) first, if you haven't already, to establish your connection to the AzureML Workspace.\n",
     "\n",
     "In this notebook you will learn how to:\n",
     "1. Creating an Experiment using an existing Workspace\n",
@@ -767,7 +767,7 @@
    "automated-machine-learning"
   ],
   "kernelspec": {
-   "display_name": "Python 3.8.5 ('base')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -790,5 +790,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-forecast-function/auto-ml-forecasting-function.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-forecast-function/auto-ml-forecasting-function.ipynb
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Please make sure you have followed the `configuration.ipynb` notebook so that your ML workspace information is saved in the config file."
+    "Please make sure you have followed the [configuration notebook](https://github.com/Azure/MachineLearningNotebooks/blob/master/configuration.ipynb) so that your ML workspace information is saved in the config file."
    ]
   },
   {

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "AutoML highlights here include using Deep Learning forecasts, Arima, Prophet,  Remote Execution and Remote Inferencing, and working with the `forecast` function. Please also look at the additional forecasting notebooks, which document lagging, rolling windows, forecast quantiles, other ways to use the forecast function, and forecaster deployment.\n",
     "\n",
-    "Make sure you have executed the [configuration](../../../configuration.ipynb) before running this notebook.\n",
+    "Make sure you have executed the [configuration](https://github.com/Azure/MachineLearningNotebooks/blob/master/configuration.ipynb) before running this notebook.\n",
     "\n",
     "Notebook synopsis:\n",
     "\n",

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-orange-juice-sales/auto-ml-forecasting-orange-juice-sales.ipynb
@@ -40,7 +40,7 @@
     "## Introduction<a id=\"introduction\"></a>\n",
     "In this example, we use AutoML to train, select, and operationalize a time-series forecasting model for multiple time-series.\n",
     "\n",
-    "Make sure you have executed the [configuration notebook](../../../configuration.ipynb) before running this notebook.\n",
+    "Make sure you have executed the [configuration notebook](https://github.com/Azure/MachineLearningNotebooks/blob/master/configuration.ipynb) before running this notebook.\n",
     "\n",
     "The examples in the follow code samples use the University of Chicago's Dominick's Finer Foods dataset to forecast orange juice sales. Dominick's was a grocery chain in the Chicago metropolitan area."
    ]

--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-pipelines/auto-ml-forecasting-pipelines.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-pipelines/auto-ml-forecasting-pipelines.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "In this notebook, we demonstrate how to use piplines to train and inference on AutoML Forecasting model. Two pipelines will be created: one for training AutoML model, and the other is for inference on AutoML model. We'll also demonstrate how to schedule the inference pipeline so you can get inference results periodically (with refreshed test dataset). Make sure you have executed the configuration notebook before running this notebook. In this notebook you will learn how to:\n",
+    "In this notebook, we demonstrate how to use piplines to train and inference on AutoML Forecasting model. Two pipelines will be created: one for training AutoML model, and the other is for inference on AutoML model. We'll also demonstrate how to schedule the inference pipeline so you can get inference results periodically (with refreshed test dataset). Make sure you have executed the [configuration notebook](https://github.com/Azure/MachineLearningNotebooks/blob/master/configuration.ipynb) before running this notebook. In this notebook you will learn how to:\n",
     "\n",
     "- Configure AutoML using AutoMLConfig for forecasting tasks using pipeline AutoMLSteps.\n",
     "- Create and register an AutoML model using AzureML pipeline.\n",


### PR DESCRIPTION
# Description
All notebooks point to a broken link for the config notebook.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
