### PR TITLE
Remove batch-cluster from infra cleanup script

### DIFF
--- a/infra/cleanup.sh
+++ b/infra/cleanup.sh
@@ -72,7 +72,6 @@ amlcompute_to_delete=(
   location-example
   low-pri-example
   ssh-example
-  batch-cluster
   gpu-cluster-nc6
 )
 for compute_name in "${amlcompute_to_delete[@]}"; do

--- a/infra/cleanup.sh
+++ b/infra/cleanup.sh
@@ -91,7 +91,7 @@ let "RegistryToBeDeleted=10#$(date -d '-1 days' +'%m%d')"
 echo "Deleting registry DemoRegistry$RegistryToBeDeleted"
 az resource delete -n DemoRegistry$RegistryToBeDeleted -g $RESOURCE_GROUP_NAME --resource-type Microsoft.MachineLearningServices/registries
 
-#delete workpsaces created by samples
+# delete workpsaces created by samples
 for workspace in $SAMPLES_WORKSPACE_LIST; do
     echo "Deleting workspace: $workspace" && az ml workspace delete -n $workspace --yes --no-wait --all-resources && echo "workspace delete initiated for: $workspace" ;
 done


### PR DESCRIPTION
# Description
The infra cleanup script is causing the [cli-scripts-batch-score](https://github.com/Azure/azureml-examples/actions/workflows/cli-scripts-batch-score.yml?query=event%3Aschedule) to fail transiently by wiping the compute whilst the test suite is running.

Given the cli-scripts-batch-score runs on a schedule, we shouldn't be wiping the underlying compute from an external cleanup script.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
