### PR TITLE
Fix share-models-components-environments notebook 

### DIFF
--- a/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
+++ b/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
@@ -403,7 +403,7 @@
     "ml_client_workspace.models.share(\n",
     "    name=\"nyc-taxi-model\",\n",
     "    version=version,\n",
-    "    registry=\"<registry-name>\",\n",
+    "    registry_name=\"<registry-name>\",\n",
     "    share_with_name=\"nyc-taxi-model-new\",\n",
     "    share_with_version=version,\n",
     ")"

--- a/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
+++ b/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
@@ -403,7 +403,7 @@
     "ml_client_workspace.models.share(\n",
     "    name=\"nyc-taxi-model\",\n",
     "    version=version,\n",
-    "    registry_name=\"<registry-name>\",\n",
+    "    registry_name=\"<REGISTRY_NAME>\",\n",
     "    share_with_name=\"nyc-taxi-model-new\",\n",
     "    share_with_version=version,\n",
     ")"

--- a/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
+++ b/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
@@ -484,7 +484,7 @@
    "outputs": [],
    "source": [
     "mlflow_model_from_registry = ml_client_registry.models.get(\n",
-    "    name=\"nyc-taxi-model\", version=version\n",
+    "    name=\"nyc-taxi-model-new\", version=version\n",
     ")\n",
     "print(mlflow_model_from_registry)"
    ]


### PR DESCRIPTION
# Description
Update `share-models-components-environments notebook ` notebook to 
include `registry_name` parameter name instead of `registry`.
# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] Pull request includes test coverage for the included changes.
