### PR TITLE
use nc6s_v3 gpu for OD tasks

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
@@ -463,7 +463,7 @@
     "    compute_config = AmlCompute(\n",
     "        name=compute_name,\n",
     "        type=\"amlcompute\",\n",
-    "        size=\"Standard_NC6\",\n",
+    "        size=\"Standard_NC6s_v3\",\n",
     "        idle_time_before_scale_down=120,\n",
     "        min_instances=0,\n",
     "        max_instances=4,\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
@@ -453,7 +453,7 @@
     "from azure.ai.ml.entities import AmlCompute\n",
     "from azure.core.exceptions import ResourceNotFoundError\n",
     "\n",
-    "compute_name = \"gpu-cluster\"\n",
+    "compute_name = \"gpu-cluster-nc6s\"\n",
     "\n",
     "try:\n",
     "    _ = ml_client.compute.get(compute_name)\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -484,7 +484,7 @@
     "    compute_config = AmlCompute(\n",
     "        name=compute_name,\n",
     "        type=\"amlcompute\",\n",
-    "        size=\"Standard_NC6\",\n",
+    "        size=\"Standard_NC6s_v3\",\n",
     "        idle_time_before_scale_down=120,\n",
     "        min_instances=0,\n",
     "        max_instances=4,\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -474,7 +474,7 @@
     "from azure.ai.ml.entities import AmlCompute\n",
     "from azure.core.exceptions import ResourceNotFoundError\n",
     "\n",
-    "compute_name = \"gpu-cluster\"\n",
+    "compute_name = \"gpu-cluster-nc6s\"\n",
     "\n",
     "try:\n",
     "    _ = ml_client.compute.get(compute_name)\n",


### PR DESCRIPTION
# Description
Mitigation for OD error below on NC6 machine
Error: Failed to validate gpu sku requirements. b'Tesla K80': Available mem_info_free:(10896.25 MB) is smaller than min_free_gpu_mem:(11000.0 MB) required.Please free some GPU RAM before submitting the run

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
