### PR TITLE
Enable Chocolatey checksums

### DIFF
--- a/setup/setup-dsvm/RStudio/Windows-Install-RStudio-opensource.ps1
+++ b/setup/setup-dsvm/RStudio/Windows-Install-RStudio-opensource.ps1
@@ -22,7 +22,7 @@
         Invoke-Expression ((New-Object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
     }
     choco feature enable --name allowGlobalConfirmation # stop the -y flag being needed for all "choco install"s
-    choco feature disable --name checksumFiles # lots of packages have no checksums, e.g. WinSDK, so allow them
+    choco feature enable --name allowEmptyChecksums # lots of packages have no checksums, e.g. WinSDK, so allow them
     choco install -y vcredist140
 	Write-Host "#### Installing Rstudio #########"
 	C:\ProgramData\chocolatey\choco install r.studio -y


### PR DESCRIPTION
Allow Chocolatey to check checkSums where they are available

# Description

Chocolatey checksums are disabled in the setup/setup-dsvm/RStudio/Windows-Install-RStudio-opensource.ps1 file. The comment is that this is because not all chocolatey packages used have checksums but the feature used will disable all checksum checks, even for packages that have them. Changing to a more secure feature which will allow installation of packages without checksums but will still check the checksums that are available.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
