### PR TITLE
Include remove connection at end of notebook.

### DIFF
--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -814,6 +814,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
+        -e "s/<python_feed_url>/https://download.pytorch.org/whl/cu113/g \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -806,7 +806,6 @@ function validate_tool() {
 
 function replace_template_values() {
     local FILENAME="$1"
-    local PYTHON_FEED_URL="https://download.pytorch.org/whl/cu113"
     echo "Replacing template values in the file: ${FILENAME}"
     sed -i -e "s/<SUBSCRIPTION_ID>/$(echo "$SUBSCRIPTION_ID")/g" \
         -e "s/<RESOURCE_GROUP>/$(echo "$RESOURCE_GROUP_NAME")/g" \
@@ -815,7 +814,6 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s;<python_feed_url>;"$PYTHON_FEED_URL";g" \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -806,6 +806,7 @@ function validate_tool() {
 
 function replace_template_values() {
     local FILENAME="$1"
+    local PYTHON_FEED_URL="https://download.pytorch.org/whl/cu113"
     echo "Replacing template values in the file: ${FILENAME}"
     sed -i -e "s/<SUBSCRIPTION_ID>/$(echo "$SUBSCRIPTION_ID")/g" \
         -e "s/<RESOURCE_GROUP>/$(echo "$RESOURCE_GROUP_NAME")/g" \
@@ -814,7 +815,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s/<python_feed_url>/"https://download.pytorch.org/whl/cu113"/g" \
+        -e "s/<python_feed_url>/$(echo "${PYTHON_FEED_URL}")/g" \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -814,7 +814,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s/<python_feed_url>/https://download.pytorch.org/whl/cu113/g" \
+        -e "s/<python_feed_url>/"https://download.pytorch.org/whl/cu113"/g" \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -806,7 +806,6 @@ function validate_tool() {
 
 function replace_template_values() {
     local FILENAME="$1"
-    local PYTHON_FEED="https://download.pytorch.org/whl/cu113"
     echo "Replacing template values in the file: ${FILENAME}"
     sed -i -e "s/<SUBSCRIPTION_ID>/$(echo "$SUBSCRIPTION_ID")/g" \
         -e "s/<RESOURCE_GROUP>/$(echo "$RESOURCE_GROUP_NAME")/g" \
@@ -815,7 +814,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s/<python_feed_url>/$(echo "$PYTHON_FEED")/g" \
+        -e "s/<python_feed_url>/https://download.pytorch.org/whl/cu113/g" \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -814,7 +814,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s/<python_feed_url>/https://download.pytorch.org/whl/cu113/g \
+        -e "s/<python_feed_url>/$(echo "https://download.pytorch.org/whl/cu113")/g \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -806,6 +806,7 @@ function validate_tool() {
 
 function replace_template_values() {
     local FILENAME="$1"
+    local PYTHON_FEED="https://download.pytorch.org/whl/cu113"
     echo "Replacing template values in the file: ${FILENAME}"
     sed -i -e "s/<SUBSCRIPTION_ID>/$(echo "$SUBSCRIPTION_ID")/g" \
         -e "s/<RESOURCE_GROUP>/$(echo "$RESOURCE_GROUP_NAME")/g" \
@@ -814,7 +815,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s/<python_feed_url>/$(echo "https://download.pytorch.org/whl/cu113")/g \
+        -e "s/<python_feed_url>/$(echo "$PYTHON_FEED")/g" \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -815,7 +815,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s/<python_feed_url>/$(echo "${PYTHON_FEED_URL}")/g" \
+        -e "s;<python_feed_url>;$(echo "${PYTHON_FEED_URL}");g" \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/infra/sdk_helpers.sh
+++ b/infra/sdk_helpers.sh
@@ -815,7 +815,7 @@ function replace_template_values() {
         -e "s/<CLUSTER_NAME>/$(echo "$ARC_CLUSTER_NAME")/g" \
         -e "s/<COMPUTE_NAME>/$(echo "$ARC_COMPUTE_NAME")/g" \
         -e "s/<TIME_STAMP>/$(echo "$timestamp")/g" \
-        -e "s;<python_feed_url>;$(echo "${PYTHON_FEED_URL}");g" \
+        -e "s;<python_feed_url>;"$PYTHON_FEED_URL";g" \
         -e "s/DefaultAzureCredential/AzureCliCredential/g" \
         -e "s/InteractiveBrowserCredential/AzureCliCredential/g" \
         -e "s/@pipeline(/&force_rerun=True,/g" \

--- a/sdk/python/resources/connections/connections.ipynb
+++ b/sdk/python/resources/connections/connections.ipynb
@@ -203,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ml_client.connections.delete(ws_connection)"
+    "ml_client.connections.delete(\"<connection_name>\")"
    ]
   }
  ],

--- a/sdk/python/resources/connections/connections.ipynb
+++ b/sdk/python/resources/connections/connections.ipynb
@@ -188,6 +188,23 @@
     "\n",
     "ml_client.connections.create_or_update(ws_connection)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. Remove a connection\n",
+    "If the connection is no longer needed, you can delete it from the workspace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ml_client.connections.delete(ws_connection)"
+   ]
   }
  ],
  "metadata": {
@@ -208,12 +225,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.12"
   },
-  "orig_nbformat": 4,
-  "vscode": {
-   "interpreter": {
-    "hash": "4c439adbb519efcfe168a123b2556c8f2fe0361cd3d8ea3ca94917232d9ad346"
-   }
-  }
+  "orig_nbformat": 4
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
This PR is to address the invalid private python feed that is on the workspace. We could have edited the replace template values for and filled in the <python_feed_url> with the proper value, but I don't know what value that is. And a public python feed fails with incorrect auth mode, since SAS auth isn't required. 

Instead, I opted to add a line at the end of the connections yaml that shows how to remove the connection. This should unblock AutoML's workflow.