### PR TITLE
Add new feature store warning to allowed_list of notebook outputs

### DIFF
--- a/v1/scripts/validation/check_notebook_output.py
+++ b/v1/scripts/validation/check_notebook_output.py
@@ -38,6 +38,7 @@ allowed_list = [
     "Please refer to aka.ms/aml-notebook-auth",
     "Class KubernetesCompute: This is an experimental class",
     "Class SynapseCompute: This is an experimental class",
+    "Class FeatureStoreOperations: This is an experimental class",
     'Please use "Dataset.File.upload_directory"',
     'Please use "FileDatasetFactory.upload_directory" instead',
     "Called AzureBlobDatastore.upload_files",


### PR DESCRIPTION
# Description
Several NLP notebooks are failing due to some new FeatureStore experimental class warning. This PR adds that to allowlist of expected warnings/outputs.

# Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [X] Pull request includes test coverage for the included changes.
