### PR TITLE
modify schedule for deploy-model, not explore-data

### DIFF
--- a/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
@@ -9,7 +9,7 @@ name: tutorials-get-started-notebooks-deploy-model
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */8 * * *"
+    - cron: "0 */12 * * *"
   pull_request:
     branches:
       - main

--- a/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
@@ -9,7 +9,7 @@ name: tutorials-get-started-notebooks-explore-data
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 */8 * * *"
   pull_request:
     branches:
       - main

--- a/tutorials/readme.py
+++ b/tutorials/readme.py
@@ -119,12 +119,13 @@ def write_notebook_workflow(
     forecast_import = get_forecast_reqs(name, nb_config)
     posix_folder = folder.replace(os.sep, "/")
     posix_notebook = notebook.replace(os.sep, "/")
+    runs_on = "ubuntu-latest"
+    workflow_sched = "0 */8 * * *"
     if "explore-data" in name:
         runs_on = "ubuntu-20.04"
+    if "deploy-model" in name:
         workflow_sched = "0 */12 * * *"
-    else:
-        runs_on = "ubuntu-latest"
-        workflow_sched = "0 */8 * * *"
+
     workflow_yaml = f"""{READONLY_HEADER}
 name: tutorials-{classification}-{name}
 # This file is created by tutorials/readme.py.


### PR DESCRIPTION
# Description
Modify readme.py to alter schedule of deploy-model notebook and leave explore-data with normal schedule.
# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
