### PR TITLE
Add job status print to batch notebooks

### DIFF
--- a/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
@@ -716,7 +716,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can wait for the job to finish using the following code:"
+    "We can wait for the job to finish and check the final status using the following code:"
    ]
   },
   {
@@ -727,7 +727,8 @@
    },
    "outputs": [],
    "source": [
-    "ml_client.jobs.stream(job.name)"
+    "ml_client.jobs.stream(job.name)\n",
+    "print(job.status)"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
@@ -716,7 +716,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can wait for the job to finish and check the final status using the following code:"
+    "We can wait for the job to finish using the following code:"
    ]
   },
   {
@@ -727,8 +727,7 @@
    },
    "outputs": [],
    "source": [
-    "ml_client.jobs.stream(job.name)\n",
-    "print(job.status)"
+    "ml_client.jobs.stream(job.name)"
    ]
   },
   {
@@ -748,6 +747,21 @@
    "outputs": [],
    "source": [
     "scoring_job = list(ml_client.jobs.list(parent_job_name=job.name))[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Job name:\", scoring_job.name)\n",
+    "print(\"Job status:\", scoring_job.status)\n",
+    "print(\n",
+    "    \"Job duration:\",\n",
+    "    scoring_job.creation_context.last_modified_at\n",
+    "    - scoring_job.creation_context.created_at,\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
@@ -784,6 +784,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Job name:\", scoring_job.name)\n",
+    "print(\"Job status:\", scoring_job.status)\n",
+    "print(\n",
+    "    \"Job duration:\",\n",
+    "    scoring_job.creation_context.last_modified_at\n",
+    "    - scoring_job.creation_context.created_at,\n",
+    ")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
@@ -1036,6 +1036,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Job name:\", scoring_job.name)\n",
+    "print(\"Job status:\", scoring_job.status)\n",
+    "print(\n",
+    "    \"Job duration:\",\n",
+    "    scoring_job.creation_context.last_modified_at\n",
+    "    - scoring_job.creation_context.created_at,\n",
+    ")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/sdk/python/endpoints/batch/deploy-models/mnist-classifier/mnist-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/mnist-classifier/mnist-batch.ipynb
@@ -1132,6 +1132,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Job name:\", scoring_job.name)\n",
+    "print(\"Job status:\", scoring_job.status)\n",
+    "print(\n",
+    "    \"Job duration:\",\n",
+    "    scoring_job.creation_context.last_modified_at\n",
+    "    - scoring_job.creation_context.created_at,\n",
+    ")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
@@ -851,6 +851,24 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Confirm the jobs' statuses using the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Preprocessing job: {preprocessing_job.status}\")\n",
+    "print(f\"Scoring job: {score_job.status}\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
@@ -534,6 +534,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Confirm the job status by accessing the child scoring job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_job = list(ml_client.jobs.list(parent_job_name=job.name))[0]\n",
+    "print(f\"Scoring job: {scoring_job.status}\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 5. Clean up resources\n",
     "\n",
     "Clean-up the resources created. "

--- a/sdk/python/endpoints/batch/deploy-pipelines/training-with-components/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/training-with-components/sdk-deploy-and-test.ipynb
@@ -844,6 +844,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Confirm the jobs' statuses using the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Preprocessing job: {preprocessing_job.status}\")\n",
+    "print(f\"Training job: {train_job.status}\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We can download the outputs as follows:"
    ]
   },


### PR DESCRIPTION
# Description
Adding lines to print the job status in each notebook. This will help with debugging. When the processing of output data fails because the job failed, we will see that clearly in the notebook output.

ICM repair item #2393567

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] Pull request includes test coverage for the included changes.
