### PR TITLE
update RAI text and vision components to v0.0.7 in notebooks

### DIFF
--- a/sdk/python/responsible-ai/text/responsibleaidashboard-multilabel-text-classification-covid-events.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-multilabel-text-classification-covid-events.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.5\""
+    "version_string = \"0.0.7\""
    ]
   },
   {
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"6\""
+    "rai_example_version_string = \"8\""
    ]
   },
   {

--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-DBPedia.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-DBPedia.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.5\""
+    "version_string = \"0.0.7\""
    ]
   },
   {
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"6\""
+    "rai_example_version_string = \"8\""
    ]
   },
   {

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-image-classification-fridge.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-image-classification-fridge.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.5\""
+    "version_string = \"0.0.7\""
    ]
   },
   {
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"6\""
+    "rai_example_version_string = \"8\""
    ]
   },
   {

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-image-multilabel-classification-fridge.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-image-multilabel-classification-fridge.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.5\""
+    "version_string = \"0.0.7\""
    ]
   },
   {
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"7\""
+    "rai_example_version_string = \"9\""
    ]
   },
   {


### PR DESCRIPTION
# Description

update RAI text and vision components to v0.0.7 in notebooks

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
