### PR TITLE
Fix tqdm warning

### DIFF
--- a/v1/scripts/validation/check_notebook_output.py
+++ b/v1/scripts/validation/check_notebook_output.py
@@ -55,6 +55,7 @@ allowed_list = [
     "Downloading builder script",
     "Downloading extra modules",
     "custom base image or base dockerfile detected",
+    "TqdmWarning: IProgress not found.",
 ]
 
 with open(full_name, "r") as notebook_file:


### PR DESCRIPTION
# Description
The tqdm warning started to show on forecasting V2 notebooks. See work item 2451413.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
