### PR TITLE
Limit import model tasks to PuP supported ones

### DIFF
--- a/sdk/python/foundation-models/system/import/import_model_into_registry.ipynb
+++ b/sdk/python/foundation-models/system/import/import_model_into_registry.ipynb
@@ -24,8 +24,6 @@
     "* text-generation\n",
     "* text-classification\n",
     "* translation\n",
-    "* image-classification\n",
-    "* text-to-image\n",
     "\n",
     "### Limitations of Model Import component where MLFlow conversion of model(s) would fail: \n",
     "1. If you attempt to download a model that has a task type other than the above with error - `Exception: Unsupported task {task name}`. \n",


### PR DESCRIPTION
# Description

Limit import model tasks to PuP supported ones. Removing image ones to be specific.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
