### PR TITLE
Except another warning line

### DIFF
--- a/v1/scripts/validation/check_notebook_output.py
+++ b/v1/scripts/validation/check_notebook_output.py
@@ -56,6 +56,7 @@ allowed_list = [
     "Downloading extra modules",
     "custom base image or base dockerfile detected",
     "TqdmWarning: IProgress not found.",
+    "from .autonotebook import tqdm as notebook_tqdm",
 ]
 
 with open(full_name, "r") as notebook_file:


### PR DESCRIPTION
# Description
Upgrading mlflow resulted in warning about widgets import. In this PR I have added second line of the warning to the exception list.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
