### PR TITLE
[Vision] InstanceSegmentation notebook fix: Avoid rendering polygon, if absent 

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -26,6 +27,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -61,6 +63,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,6 +105,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -115,6 +119,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -163,6 +168,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -182,6 +188,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -220,6 +227,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -329,6 +337,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -471,6 +480,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -499,6 +509,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -535,6 +546,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -544,6 +556,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -617,6 +630,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -648,6 +662,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -715,6 +730,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -831,6 +847,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -848,6 +865,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -856,6 +874,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -872,6 +891,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -920,6 +940,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -955,6 +976,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -979,6 +1001,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -998,6 +1021,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1049,6 +1073,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1056,6 +1081,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1114,6 +1140,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1156,6 +1183,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1212,6 +1240,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1235,6 +1264,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1294,6 +1324,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1359,26 +1390,28 @@
     "\n",
     "        ax.add_patch(rect)\n",
     "        plt.text(topleft_x, topleft_y - 10, label, color=color, fontsize=20)\n",
-    "\n",
-    "        polygon_np = np.array(polygon[0])\n",
-    "        polygon_np = polygon_np.reshape(-1, 2)\n",
-    "        polygon_np[:, 0] *= x\n",
-    "        polygon_np[:, 1] *= y\n",
-    "        poly = patches.Polygon(polygon_np, True, facecolor=color, alpha=0.4)\n",
-    "        ax.add_patch(poly)\n",
-    "        poly_line = Line2D(\n",
-    "            polygon_np[:, 0],\n",
-    "            polygon_np[:, 1],\n",
-    "            linewidth=2,\n",
-    "            marker=\"o\",\n",
-    "            markersize=8,\n",
-    "            markerfacecolor=color,\n",
-    "        )\n",
-    "        ax.add_line(poly_line)\n",
+    "        \n",
+    "        if polygon:\n",
+    "            polygon_np = np.array(polygon[0])\n",
+    "            polygon_np = polygon_np.reshape(-1, 2)\n",
+    "            polygon_np[:, 0] *= x\n",
+    "            polygon_np[:, 1] *= y\n",
+    "            poly = patches.Polygon(polygon_np, True, facecolor=color, alpha=0.4)\n",
+    "            ax.add_patch(poly)\n",
+    "            poly_line = Line2D(\n",
+    "                polygon_np[:, 0],\n",
+    "                polygon_np[:, 1],\n",
+    "                linewidth=2,\n",
+    "                marker=\"o\",\n",
+    "                markersize=8,\n",
+    "                markerfacecolor=color,\n",
+    "            )\n",
+    "            ax.add_line(poly_line)\n",
     "plt.show()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1395,6 +1428,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1412,6 +1446,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1420,6 +1455,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": []

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -1390,7 +1390,7 @@
     "\n",
     "        ax.add_patch(rect)\n",
     "        plt.text(topleft_x, topleft_y - 10, label, color=color, fontsize=20)\n",
-    "        \n",
+    "\n",
     "        if polygon and len(polygon) > 0:\n",
     "            polygon_np = np.array(polygon[0])\n",
     "            polygon_np = polygon_np.reshape(-1, 2)\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -1391,7 +1391,7 @@
     "        ax.add_patch(rect)\n",
     "        plt.text(topleft_x, topleft_y - 10, label, color=color, fontsize=20)\n",
     "        \n",
-    "        if polygon:\n",
+    "        if polygon and len(polygon) > 0:\n",
     "            polygon_np = np.array(polygon[0])\n",
     "            polygon_np = polygon_np.reshape(-1, 2)\n",
     "            polygon_np[:, 0] *= x\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/mlflow-model-local-inference-test.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/mlflow-model-local-inference-test.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -25,6 +26,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -52,6 +54,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -105,6 +108,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -148,6 +152,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -216,25 +221,27 @@
     "        ax.add_patch(rect)\n",
     "        plt.text(topleft_x, topleft_y - 10, label, color=color, fontsize=20)\n",
     "\n",
-    "        polygon_np = np.array(polygon[0])\n",
-    "        polygon_np = polygon_np.reshape(-1, 2)\n",
-    "        polygon_np[:, 0] *= x\n",
-    "        polygon_np[:, 1] *= y\n",
-    "        poly = patches.Polygon(polygon_np, True, facecolor=color, alpha=0.4)\n",
-    "        ax.add_patch(poly)\n",
-    "        poly_line = Line2D(\n",
-    "            polygon_np[:, 0],\n",
-    "            polygon_np[:, 1],\n",
-    "            linewidth=2,\n",
-    "            marker=\"o\",\n",
-    "            markersize=8,\n",
-    "            markerfacecolor=color,\n",
-    "        )\n",
-    "        ax.add_line(poly_line)\n",
+    "        if polygon:\n",
+    "            polygon_np = np.array(polygon[0])\n",
+    "            polygon_np = polygon_np.reshape(-1, 2)\n",
+    "            polygon_np[:, 0] *= x\n",
+    "            polygon_np[:, 1] *= y\n",
+    "            poly = patches.Polygon(polygon_np, True, facecolor=color, alpha=0.4)\n",
+    "            ax.add_patch(poly)\n",
+    "            poly_line = Line2D(\n",
+    "                polygon_np[:, 0],\n",
+    "                polygon_np[:, 1],\n",
+    "                linewidth=2,\n",
+    "                marker=\"o\",\n",
+    "                markersize=8,\n",
+    "                markerfacecolor=color,\n",
+    "            )\n",
+    "            ax.add_line(poly_line)\n",
     "plt.show()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -243,6 +250,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": []

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/mlflow-model-local-inference-test.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/mlflow-model-local-inference-test.ipynb
@@ -221,7 +221,7 @@
     "        ax.add_patch(rect)\n",
     "        plt.text(topleft_x, topleft_y - 10, label, color=color, fontsize=20)\n",
     "\n",
-    "        if polygon:\n",
+    "        if polygon and len(polygon) > 0:\n",
     "            polygon_np = np.array(polygon[0])\n",
     "            polygon_np = polygon_np.reshape(-1, 2)\n",
     "            polygon_np[:, 0] *= x\n",
@@ -257,9 +257,6 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "289dd8ba56d14462f802fc494f900f580a323d52d317644c669d12d1794296a4"
-  },
   "kernel_info": {
    "name": "python3-azureml"
   },


### PR DESCRIPTION
# Description
Added a check to avoid rendering polygon, if absent in response.
This is to avoid IndexError

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [X] Pull request includes test coverage for the included changes.
