### PR TITLE
install latest mltable for parallel sample

### DIFF
--- a/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/src/environment_parallel.yml
+++ b/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/src/environment_parallel.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - pip:
       - mlflow
+      - mltable>=1.2.0
       - azureml-dataset-runtime[pandas,fuse]
       - azureml-telemetry
       - pandas


### PR DESCRIPTION
# Description

The PRS run-time have migrated to use mltable SDK for replacing the deprecated API. Please install the latest 'mltable' package into your environment. you can refer to https://github.com/Azure/azureml-examples/blob/main/cli/jobs/parallel/2a_iris_batch_prediction/environment/environment_parallel.yml

Please check logs for error. You can check logs/readme.txt for the layout of logs.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
