### PR TITLE
fix object detection notebook example on dataset fetch in build CI and improve header documentation

### DIFF
--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-object-detection-MSCOCO.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-object-detection-MSCOCO.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Image Object Detection scenario with RAI Dashboard\n",
+    "\n",
+    "The [object detection fridge dataset](https://github.com/microsoft/computervision-recipes/tree/master/scenarios/detection) provides images and bounding boxes with four types of items commonly found in the Microsoft New England R&D office refrigerator - carton, water bottle, can and milk bottle.  This example notebook demonstrates how to use a Faster R-CNN ResNet 50 FPN computer vision model from torchvision on the dataset to evaluate the model in AzureML.\n",
+    "\n",
+    "First, we need to specify the version of the RAI components which are available in the workspace. This was specified when the components were uploaded."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -206,14 +218,20 @@
     "\n",
     "input_test_data = \"MSCOCO_Test_MLTable_OD18\"\n",
     "\n",
-    "test_data = Data(\n",
-    "    path=data_path,\n",
-    "    type=AssetTypes.MLTABLE,\n",
-    "    description=\"RAI MSCOCO data\",\n",
-    "    name=input_test_data,\n",
-    "    version=rai_example_version_string,\n",
-    ")\n",
-    "ml_client.data.create_or_update(test_data)"
+    "try:\n",
+    "    test_data = ml_client.data.get(\n",
+    "        name=input_test_data,\n",
+    "        version=rai_example_version_string,\n",
+    "    )\n",
+    "except Exception:\n",
+    "    test_data = Data(\n",
+    "        path=data_path,\n",
+    "        type=AssetTypes.MLTABLE,\n",
+    "        description=\"RAI MSCOCO data\",\n",
+    "        name=input_test_data,\n",
+    "        version=rai_example_version_string,\n",
+    "    )\n",
+    "    ml_client.data.create_or_update(test_data)"
    ]
   },
   {


### PR DESCRIPTION
# Description

The object detection notebook with RAI was just merged.  When trying to add another notebook example, I found that the object detection notebook started failing when registering a dataset, because it was already registered in a previous run against the test workspace used:

```
HttpResponseError                         Traceback (most recent call last)
Cell In[8], line 13
      4 input_test_data = "MSCOCO_Test_MLTable_OD18"
      6 test_data = Data(
      7     path=data_path,
      8     type=AssetTypes.MLTABLE,
   (...)
     11     version=rai_example_version_string,
     12 )
---> 13 ml_client.data.create_or_update(test_data)
...
HttpResponseError: (UserError) A data version with this name and version already exists. If you are trying to create a new data version, use a different name or version. If you are trying to update an existing data version, the existing asset's data uri cannot be changed. Only tags, description, and isArchived can be updated.
Code: UserError
```

Link to build failure:
https://github.com/Azure/azureml-examples/actions/runs/5446414448/jobs/9907120291?pr=2423

To fix this build issue, the notebook should be following the logic of other notebooks, which is to have a try/except around the dataset fetch logic and simply get the dataset if it already exists in the test workspace instead of trying to add it.

In addition to the fix for the notebook CI test failures, I also added a title and documentation header at the top of the notebook similar to the other RAI notebooks to be consistent.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] Pull request includes test coverage for the included changes.
