### PR TITLE
chore: Update cron schedule for automated-cleanup-resources

### DIFF
--- a/.github/workflows/automated-cleanup-resources.yml
+++ b/.github/workflows/automated-cleanup-resources.yml
@@ -2,7 +2,7 @@ name: automated-cleanup-resources
 on:
   workflow_dispatch:
   schedule:
-    - cron: "45 */12 * * *"
+    - cron: "0 8 * * *"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# Description

This pull request updates the cron schedule for automated-cleanup-resources from `45 */12 * * *` (45th minute of every 12th hour) to `0 8 * * *` (At 8:00am UTC or roughly 1:00am PST)

There exists a race condition between the resources created by long running samples, and the cleanup scripts that run periodically. Changing the schedule attempts to minimize the opportunity for the cleanup script to delete a resource that is in use.


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
