### PR TITLE
switch from building inf env to using train env

### DIFF
--- a/v1/python-sdk/tutorials/automl-with-azureml/forecasting-pipelines/auto-ml-forecasting-pipelines.ipynb
+++ b/v1/python-sdk/tutorials/automl-with-azureml/forecasting-pipelines/auto-ml-forecasting-pipelines.ipynb
@@ -555,40 +555,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from azureml.core import Model\n",
+    "from azureml.train.automl.run import AutoMLRun\n",
     "\n",
-    "model = Model(ws, model_name_str)\n",
-    "download_path = model.download(model_name_str, exist_ok=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "After all the files are downloaded, we can generate the run config for inference runs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from azureml.core import Environment, RunConfiguration\n",
-    "from azureml.core.conda_dependencies import CondaDependencies\n",
+    "for step in training_pipeline_run.get_steps():\n",
+    "    if step.properties.get(\"StepType\") == \"AutoMLStep\":\n",
+    "        automl_run = AutoMLRun(experiment, step.id)\n",
+    "        break\n",
     "\n",
-    "env_file = os.path.join(download_path, \"conda_env_v_1_0_0.yml\")\n",
-    "inference_env = Environment(\"oj-inference-env\")\n",
-    "inference_env.python.conda_dependencies = CondaDependencies(\n",
-    "    conda_dependencies_file_path=env_file\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "[Optional] The enviroment can also be assessed from the training run using `get_environment()` API."
+    "best_run = automl_run.get_best_child()\n",
+    "inference_env = best_run.get_environment()"
    ]
   },
   {


### PR DESCRIPTION
# Description
Building environment during inference is continuously timing out in the eastus2 region. This PR switches from building inference environment to using the already built training environment. This nb has been failing since 23rd, let's get this merged ASAP.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
