### PR TITLE
pin compute metrics component to 0.0.10.

### DIFF
--- a/cli/jobs/pipelines/automl/cli-automl-forecasting-demand-with-pipeline-components/cli-automl-forecasting-demand-hierarchical-timeseries/hts_evaluation_pipeline.yml
+++ b/cli/jobs/pipelines/automl/cli-automl-forecasting-demand-with-pipeline-components/cli-automl-forecasting-demand-hierarchical-timeseries/hts_evaluation_pipeline.yml
@@ -74,7 +74,7 @@ jobs:
 
   compute_metrics:
     type: command
-    component: azureml://registries/azureml/components/compute_metrics
+    component: azureml://registries/azureml/components/compute_metrics/versions/0.0.10
     inputs:
       task: "tabular-forecasting"
       ground_truth: ${{parent.jobs.automl_hts_inference.outputs.evaluation_data}}

--- a/cli/jobs/pipelines/automl/cli-automl-forecasting-demand-with-pipeline-components/cli-automl-forecasting-demand-many-models/many_models_evaluation_pipeline.yml
+++ b/cli/jobs/pipelines/automl/cli-automl-forecasting-demand-with-pipeline-components/cli-automl-forecasting-demand-many-models/many_models_evaluation_pipeline.yml
@@ -74,7 +74,7 @@ jobs:
 
   compute_metrics:
     type: command
-    component: azureml://registries/azureml/components/compute_metrics
+    component: azureml://registries/azureml/components/compute_metrics/versions/0.0.10
     inputs:
       task: "tabular-forecasting"
       ground_truth: ${{parent.jobs.automl_mm_inference.outputs.evaluation_data}}

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-distributed-tcn/automl-forecasting-distributed-tcn.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-distributed-tcn/automl-forecasting-distributed-tcn.ipynb
@@ -685,7 +685,8 @@
    "outputs": [],
    "source": [
     "compute_metrics_component = ml_client_registry.components.get(\n",
-    "    name=\"compute_metrics\", label=\"latest\"\n",
+    "    name=\"compute_metrics\",\n",
+    "    version=\"0.0.10\",  # label=\"latest\"\n",
     ")\n",
     "print(f\"Compute metrics component version: {compute_metrics_component.version}\\n---\")"
    ]

--- a/sdk/python/jobs/pipelines/1k_demand_forecasting_with_pipeline_components/automl-forecasting-demand-hierarchical-timeseries-in-pipeline/automl-forecasting-demand-hierarchical-timeseries-in-pipeline.ipynb
+++ b/sdk/python/jobs/pipelines/1k_demand_forecasting_with_pipeline_components/automl-forecasting-demand-hierarchical-timeseries-in-pipeline/automl-forecasting-demand-hierarchical-timeseries-in-pipeline.ipynb
@@ -423,7 +423,8 @@
    "outputs": [],
    "source": [
     "compute_metrics_component = ml_client_registry.components.get(\n",
-    "    name=\"compute_metrics\", label=\"latest\"\n",
+    "    name=\"compute_metrics\",\n",
+    "    version=\"0.0.10\",  # label=\"latest\"\n",
     ")\n",
     "print(f\"Compute metrics component version: {compute_metrics_component.version}\\n---\")"
    ]

--- a/sdk/python/jobs/pipelines/1k_demand_forecasting_with_pipeline_components/automl-forecasting-demand-many-models-in-pipeline/automl-forecasting-demand-many-models-in-pipeline.ipynb
+++ b/sdk/python/jobs/pipelines/1k_demand_forecasting_with_pipeline_components/automl-forecasting-demand-many-models-in-pipeline/automl-forecasting-demand-many-models-in-pipeline.ipynb
@@ -432,7 +432,8 @@
    "outputs": [],
    "source": [
     "compute_metrics_component = ml_client_registry.components.get(\n",
-    "    name=\"compute_metrics\", label=\"latest\"\n",
+    "    name=\"compute_metrics\",\n",
+    "    version=\"0.0.10\",  # label=\"latest\"\n",
     ")\n",
     "print(\n",
     "    f\"Many models inference component version: {compute_metrics_component.version}\\n---\"\n",


### PR DESCRIPTION
pin compute metrics component to 0.0.10. The latest [PR ](https://github.com/Azure/azureml-assets/commit/763e0900ddde53e1a47f7dc09b3bb2165c25088d) broke the forecasting functionality, and the evaluation pipelines are no longer working. Pinning this version until latest component issues are resolved.

# Description


# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
