### PR TITLE
Adding the retry logic for csv

### DIFF
--- a/cli/foundation-models/system/finetune/image-classification/multiclass-classification/hftransformers-fridgeobjects-multiclass-classification-pipeline.yaml
+++ b/cli/foundation-models/system/finetune/image-classification/multiclass-classification/hftransformers-fridgeobjects-multiclass-classification-pipeline.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 type: pipeline
 
-experiment_name: AzureML-Train-Finetune-Vision-MultiClass-Samples
+experiment_name: AzureML-Cli-Train-Finetune-Vision-MultiClass-Samples
 
 inputs:
   # # Model - specify the foundation model available in the azureml system registry

--- a/cli/foundation-models/system/finetune/image-classification/multiclass-classification/hftransformers-fridgeobjects-multiclass-classification.sh
+++ b/cli/foundation-models/system/finetune/image-classification/multiclass-classification/hftransformers-fridgeobjects-multiclass-classification.sh
@@ -154,9 +154,7 @@ az ml online-deployment create --file ./deploy.yaml $workspace_info --all-traffi
 
 # Check if scoring data file exists
 if [ -f $huggingface_sample_request_data ]; then
-    echo "Invoking endpoint $huggingface_endpoint_name with following input:\n\n"
-    cat $huggingface_sample_request_data
-    echo "\n\n"
+    echo "Invoking endpoint $huggingface_endpoint_name with $huggingface_sample_request_data\n\n"
 else
     echo "Scoring file $huggingface_sample_request_data does not exist"
     exit 1

--- a/cli/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification-pipeline.yaml
+++ b/cli/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification-pipeline.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 type: pipeline
 
-experiment_name: AzureML-Train-Finetune-Vision-MultiLabel-Samples
+experiment_name: AzureML-Cli-Train-Finetune-Vision-MultiLabel-Samples
 
 inputs:
   # # Model - specify the foundation model available in the azureml system registry

--- a/cli/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.sh
+++ b/cli/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.sh
@@ -155,9 +155,7 @@ az ml online-deployment create --file ./deploy.yaml $workspace_info --all-traffi
 
 # Check if scoring data file exists
 if [ -f $huggingface_sample_request_data ]; then
-    echo "Invoking endpoint $huggingface_endpoint_name with following input:\n\n"
-    cat $huggingface_sample_request_data
-    echo "\n\n"
+    echo "Invoking endpoint $huggingface_endpoint_name with $huggingface_sample_request_data\n\n"
 else
     echo "Scoring file $huggingface_sample_request_data does not exist"
     exit 1

--- a/cli/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.sh
+++ b/cli/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.sh
@@ -37,6 +37,7 @@ huggingface_sample_request_data="./huggingface_sample_request_data.json"
 
 # finetuning job parameters
 finetuning_pipeline_component="transformers_image_classification_pipeline"
+
 # Training settings
 process_count_per_instance=$gpus_per_node # set to the number of GPUs available in the compute
 

--- a/cli/foundation-models/system/finetune/image-instance-segmentation/mmdetection-fridgeobjects-instance-segmentation-pipeline.yml
+++ b/cli/foundation-models/system/finetune/image-instance-segmentation/mmdetection-fridgeobjects-instance-segmentation-pipeline.yml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 type: pipeline
 
-experiment_name: AzureML-Train-Finetune-Vision-Instance-Segmentation-Samples
+experiment_name: AzureML-Cli-Train-Finetune-Vision-IS-Samples
 
 inputs:
   # dataset files

--- a/cli/foundation-models/system/finetune/image-instance-segmentation/mmdetection-fridgeobjects-instance-segmentation.sh
+++ b/cli/foundation-models/system/finetune/image-instance-segmentation/mmdetection-fridgeobjects-instance-segmentation.sh
@@ -159,9 +159,7 @@ az ml online-deployment create --file ./deploy.yaml $workspace_info --all-traffi
 # Check if scoring data file exists
 if [ -f $mmdetection_sample_request_data ] 
 then
-    echo "Invoking endpoint $mmdetection_sample_request_data with following input:\n\n"
-    cat $mmdetection_sample_request_data
-    echo "\n\n"
+    echo "Invoking endpoint $mmdetection_endpoint_name with $mmdetection_sample_request_data\n\n"
 else
     echo "Scoring file $mmdetection_sample_request_data does not exist"
     exit 1

--- a/cli/foundation-models/system/finetune/image-object-detection/mmdetection-fridgeobjects-detection-pipeline.yml
+++ b/cli/foundation-models/system/finetune/image-object-detection/mmdetection-fridgeobjects-detection-pipeline.yml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 type: pipeline
 
-experiment_name: AzureML-Train-Finetune-Vision-Object-Detection-Samples
+experiment_name: AzureML-Cli-Train-Finetune-Vision-OD-Samples
 
 inputs:
   # dataset files

--- a/cli/foundation-models/system/finetune/image-object-detection/mmdetection-fridgeobjects-detection.sh
+++ b/cli/foundation-models/system/finetune/image-object-detection/mmdetection-fridgeobjects-detection.sh
@@ -158,9 +158,7 @@ az ml online-deployment create --file ./deploy.yaml $workspace_info --all-traffi
 # Check if scoring data file exists
 if [ -f $mmdetection_sample_request_data ] 
 then
-    echo "Invoking endpoint $mmdetection_sample_request_data with following input:\n\n"
-    cat $mmdetection_sample_request_data
-    echo "\n\n"
+    echo "Invoking endpoint $mmdetection_endpoint_name with $mmdetection_sample_request_data\n\n"
 else
     echo "Scoring file $mmdetection_sample_request_data does not exist"
     exit 1

--- a/cli/foundation-models/system/inference/image-classification/image-classification-batch-endpoint.sh
+++ b/cli/foundation-models/system/inference/image-classification/image-classification-batch-endpoint.sh
@@ -24,18 +24,11 @@ endpoint_name="image-classification-$version"
 deployment_name="demo-$version"
 
 # Prepare data for deployment
-multi_label=0
 data_path="data_batch"
-python ./prepare_data.py --is_multilabel $multi_label --mode "batch" --data_path $data_path
+python ./prepare_data.py --is_multilabel 0 --mode "batch" --data_path $data_path
 # sample request data in csv format with image column
-if [ $multi_label -eq 1 ]
-then
-    sample_request_csv="./data_batch/image_classification_multilabel_lis.csv"
-    sample_request_folder="./data_batch/multilabelFridgeObjects"
-else
-    sample_request_csv="./data_batch/image_classification_multiclass_list.csv"
-    sample_request_folder="./data_batch/fridgeObjects"
-fi
+sample_request_csv="./data_batch/image_classification_multiclass_list.csv"
+sample_request_folder="./data_batch/fridgeObjects"
 
 # 1. Setup pre-requisites
 if [ "$subscription_id" = "<SUBSCRIPTION_ID>" ] || \

--- a/cli/foundation-models/system/inference/image-classification/image-classification-online-endpoint.sh
+++ b/cli/foundation-models/system/inference/image-classification/image-classification-online-endpoint.sh
@@ -21,13 +21,7 @@ deployment_sku="Standard_DS3_v2"
 # Prepare data for deployment
 python ./prepare_data.py --is_multilabel 0 --data_path "data_online" --mode "online"
 # sample_request_data
-if [ $multi_label -eq 1 ]
-then
-    sample_request_data="./data_online/multilabelFridgeObjects/sample_request_data.json"
-else
-    sample_request_data="./data_online/fridgeObjects/sample_request_data.json"
-fi
-
+sample_request_data="./data_online/fridgeObjects/sample_request_data.json"
 # 1. Setup pre-requisites
 if [ "$subscription_id" = "<SUBSCRIPTION_ID>" ] || \
    ["$resource_group_name" = "<RESOURCE_GROUP>" ] || \

--- a/cli/foundation-models/system/inference/image-classification/image-classification-online-endpoint.sh
+++ b/cli/foundation-models/system/inference/image-classification/image-classification-online-endpoint.sh
@@ -61,9 +61,7 @@ az ml online-deployment create --file deploy-online.yaml $workspace_info --all-t
 
 # Check if scoring data file exists
 if [ -f $sample_request_data ]; then
-    echo "Invoking endpoint $endpoint_name with following input:\n\n"
-    cat $sample_request_data
-    echo "\n\n"
+    echo "Invoking endpoint $endpoint_name with $sample_request_data\n\n"
 else
     echo "Scoring file $sample_request_data does not exist"
     exit 1

--- a/cli/foundation-models/system/inference/image-instance-segmentation/image-instance-segmentation-online-endpoint.sh
+++ b/cli/foundation-models/system/inference/image-instance-segmentation/image-instance-segmentation-online-endpoint.sh
@@ -62,9 +62,7 @@ az ml online-deployment create --file deploy-online.yaml $workspace_info --all-t
 
 # Check if scoring data file exists
 if [ -f $sample_request_data ]; then
-    echo "Invoking endpoint $endpoint_name with following input:\n\n"
-    cat $sample_request_data
-    echo "\n\n"
+    echo "Invoking endpoint $endpoint_name with $sample_request_data\n\n"
 else
     echo "Scoring file $sample_request_data does not exist"
     exit 1

--- a/cli/foundation-models/system/inference/image-object-detection/image-object-detection-online-endpoint.sh
+++ b/cli/foundation-models/system/inference/image-object-detection/image-object-detection-online-endpoint.sh
@@ -64,9 +64,7 @@ az ml online-deployment create --file deploy-online.yaml $workspace_info --all-t
 
 # Check if scoring data file exists
 if [ -f $sample_request_data ]; then
-    echo "Invoking endpoint $endpoint_name with following input:\n\n"
-    cat $sample_request_data
-    echo "\n\n"
+    echo "Invoking endpoint $endpoint_name with $sample_request_data\n\n"
 else
     echo "Scoring file $sample_request_data does not exist"
     exit 1

--- a/sdk/python/foundation-models/system/finetune/image-classification/multiclass-classification/hftransformers-fridgeobjects-multiclass-classification.ipynb
+++ b/sdk/python/foundation-models/system/finetune/image-classification/multiclass-classification/hftransformers-fridgeobjects-multiclass-classification.ipynb
@@ -1079,22 +1079,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "dri",
-   "language": "python",
-   "name": "dri"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/sdk/python/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.ipynb
+++ b/sdk/python/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.ipynb
@@ -213,9 +213,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "huggingface_model_name = \"microsoft/beit-base-patch16-224-pt22k-ft22k\"\n",
+    "huggingface_model_name = \"google-vit-base-patch16-224\"\n",
     "\n",
-    "aml_registry_model_name = \"microsoft-beit-base-patch16-224-pt22k-ft22k\"\n",
+    "aml_registry_model_name = \"google-vit-base-patch16-224\"\n",
     "foundation_models = registry_ml_client.models.list(aml_registry_model_name)\n",
     "foundation_model = max(foundation_models, key=lambda x: x.version)\n",
     "print(f\"\\n\\nUsing model name: {foundation_model.name}, version: {foundation_model.version}, id: {foundation_model.id} for fine tuning\")"
@@ -1097,10 +1097,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
+    "language_info": {
+     "name": "python"
+    }
+},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/sdk/python/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.ipynb
+++ b/sdk/python/foundation-models/system/finetune/image-classification/multilabel-classification/hftransformers-fridgeobjects-multilabel-classification.ipynb
@@ -213,9 +213,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "huggingface_model_name = \"google-vit-base-patch16-224\"\n",
+    "huggingface_model_name = \"microsoft/beit-base-patch16-224-pt22k-ft22k\"\n",
     "\n",
-    "aml_registry_model_name = \"google-vit-base-patch16-224\"\n",
+    "aml_registry_model_name = \"microsoft-beit-base-patch16-224-pt22k-ft22k\"\n",
     "foundation_models = registry_ml_client.models.list(aml_registry_model_name)\n",
     "foundation_model = max(foundation_models, key=lambda x: x.version)\n",
     "print(f\"\\n\\nUsing model name: {foundation_model.name}, version: {foundation_model.version}, id: {foundation_model.id} for fine tuning\")"
@@ -1097,10 +1097,10 @@
   }
  ],
  "metadata": {
-    "language_info": {
-     "name": "python"
-    }
-},
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/sdk/python/foundation-models/system/inference/image-classification/image-classification-batch-endpoint.ipynb
+++ b/sdk/python/foundation-models/system/inference/image-classification/image-classification-batch-endpoint.ipynb
@@ -443,11 +443,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
+    "def invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path):\n",
+    "    input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
+    "    job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
+    "    workspace_ml_client.jobs.stream(job.name)\n",
+    "    return job\n",
     "\n",
-    "job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
-    "\n",
-    "workspace_ml_client.jobs.stream(job.name)"
+    "job = None\n",
+    "num_retries = 3\n",
+    "for i in range(num_retries):\n",
+    "    try:\n",
+    "        job = invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path)\n",
+    "        break\n",
+    "    except Exception as e:\n",
+    "        if i == num_retries - 1:\n",
+    "            raise e\n",
+    "        else:\n",
+    "            print(\"Endpoint invocation failed. Retrying after 5 seconds...\")\n",
+    "            time.sleep(5)"
    ]
   },
   {

--- a/sdk/python/foundation-models/system/inference/image-classification/image-classification-batch-endpoint.ipynb
+++ b/sdk/python/foundation-models/system/inference/image-classification/image-classification-batch-endpoint.ipynb
@@ -443,24 +443,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path):\n",
-    "    input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
-    "    job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
-    "    workspace_ml_client.jobs.stream(job.name)\n",
-    "    return job\n",
-    "\n",
     "job = None\n",
+    "input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
     "num_retries = 3\n",
     "for i in range(num_retries):\n",
     "    try:\n",
-    "        job = invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path)\n",
+    "        job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
     "        break\n",
     "    except Exception as e:\n",
     "        if i == num_retries - 1:\n",
     "            raise e\n",
     "        else:\n",
     "            print(\"Endpoint invocation failed. Retrying after 5 seconds...\")\n",
-    "            time.sleep(5)"
+    "            time.sleep(5)\n",
+    "if job is not None:\n",
+    "    workspace_ml_client.jobs.stream(job.name)"
    ]
   },
   {

--- a/sdk/python/foundation-models/system/inference/image-instance-segmentation/image-instance-segmentation-batch-endpoint.ipynb
+++ b/sdk/python/foundation-models/system/inference/image-instance-segmentation/image-instance-segmentation-batch-endpoint.ipynb
@@ -426,11 +426,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
+    "def invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path):\n",
+    "    input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
+    "    job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
+    "    workspace_ml_client.jobs.stream(job.name)\n",
+    "    return job\n",
     "\n",
-    "job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
-    "\n",
-    "workspace_ml_client.jobs.stream(job.name)"
+    "job = None\n",
+    "num_retries = 3\n",
+    "for i in range(num_retries):\n",
+    "    try:\n",
+    "        job = invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path)\n",
+    "        break\n",
+    "    except Exception as e:\n",
+    "        if i == num_retries - 1:\n",
+    "            raise e\n",
+    "        else:\n",
+    "            print(\"Endpoint invocation failed. Retrying after 5 seconds...\")\n",
+    "            time.sleep(5)"
    ]
   },
   {

--- a/sdk/python/foundation-models/system/inference/image-instance-segmentation/image-instance-segmentation-batch-endpoint.ipynb
+++ b/sdk/python/foundation-models/system/inference/image-instance-segmentation/image-instance-segmentation-batch-endpoint.ipynb
@@ -426,24 +426,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path):\n",
-    "    input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
-    "    job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
-    "    workspace_ml_client.jobs.stream(job.name)\n",
-    "    return job\n",
-    "\n",
     "job = None\n",
+    "input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
     "num_retries = 3\n",
     "for i in range(num_retries):\n",
     "    try:\n",
-    "        job = invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path)\n",
+    "        job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
     "        break\n",
     "    except Exception as e:\n",
     "        if i == num_retries - 1:\n",
     "            raise e\n",
     "        else:\n",
     "            print(\"Endpoint invocation failed. Retrying after 5 seconds...\")\n",
-    "            time.sleep(5)"
+    "            time.sleep(5)\n",
+    "if job is not None:\n",
+    "    workspace_ml_client.jobs.stream(job.name)"
    ]
   },
   {

--- a/sdk/python/foundation-models/system/inference/image-object-detection/image-object-detection-batch-endpoint.ipynb
+++ b/sdk/python/foundation-models/system/inference/image-object-detection/image-object-detection-batch-endpoint.ipynb
@@ -426,11 +426,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
+    "def invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path):\n",
+    "    input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
+    "    job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
+    "    workspace_ml_client.jobs.stream(job.name)\n",
+    "    return job\n",
     "\n",
-    "job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
-    "\n",
-    "workspace_ml_client.jobs.stream(job.name)"
+    "job = None\n",
+    "num_retries = 3\n",
+    "for i in range(num_retries):\n",
+    "    try:\n",
+    "        job = invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path)\n",
+    "        break\n",
+    "    except Exception as e:\n",
+    "        if i == num_retries - 1:\n",
+    "            raise e\n",
+    "        else:\n",
+    "            print(\"Endpoint invocation failed. Retrying after 5 seconds...\")\n",
+    "            time.sleep(5)"
    ]
   },
   {

--- a/sdk/python/foundation-models/system/inference/image-object-detection/image-object-detection-batch-endpoint.ipynb
+++ b/sdk/python/foundation-models/system/inference/image-object-detection/image-object-detection-batch-endpoint.ipynb
@@ -426,24 +426,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path):\n",
-    "    input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
-    "    job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
-    "    workspace_ml_client.jobs.stream(job.name)\n",
-    "    return job\n",
-    "\n",
     "job = None\n",
+    "input = Input(path=csv_file_path, type=AssetTypes.URI_FILE)\n",
     "num_retries = 3\n",
     "for i in range(num_retries):\n",
     "    try:\n",
-    "        job = invoke_batch_endpoint(workspace_ml_client, endpoint, csv_file_path)\n",
+    "        job = workspace_ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)\n",
     "        break\n",
     "    except Exception as e:\n",
     "        if i == num_retries - 1:\n",
     "            raise e\n",
     "        else:\n",
     "            print(\"Endpoint invocation failed. Retrying after 5 seconds...\")\n",
-    "            time.sleep(5)"
+    "            time.sleep(5)\n",
+    "if job is not None:\n",
+    "    workspace_ml_client.jobs.stream(job.name)"
    ]
   },
   {


### PR DESCRIPTION
# Description

1. Added the retry logic for batch deployment notebooks using csv file
2. Removed multilabel deployment flag from cli deployment(online and batch)
3. Converted FT cli job from windows format to unix format("\r\n" issue)
4. Cli FT experiment name change(added "CLI" in all cli experiment names)
5. Removed kernelspec from notebooks metadata
6. Remove the cat statement from online endpoint invocation section
# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
