### PR TITLE
fix: PR Size Limit

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Check Pull Request Size
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }} --quiet # Need to manually fetch base branch in CI
-          python ./.github/scripts/commit-filesize-diff-summary.py --limit 100MB origin/${{ github.event.pull_request.base.ref }}..HEAD
+          python ./.github/scripts/commit-filesize-diff-summary.py --limit 2MB origin/${{ github.event.pull_request.base.ref }}..HEAD


### PR DESCRIPTION
# Description

This PR resets the size limit for PRs that was temporarily lifted in a revert commit.

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
