### PR TITLE
Removed time.sleep() after init_online_lookup() in online FS samples

### DIFF
--- a/sdk/python/featurestore_sample/notebooks/sdk_only/5. Enable online store and run online inference.ipynb
+++ b/sdk/python/featurestore_sample/notebooks/sdk_only/5. Enable online store and run online inference.ipynb
@@ -776,7 +776,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following code cell tracks completion of the backfill job. Using the premium tier Azure Cache for Redis provisioned earlier, this step may take approximately 3-4 minutes to complete."
+    "The following code cell tracks completion of the backfill job. Using the premium tier Azure Cache for Redis provisioned earlier, this step may take approximately 5 minutes to complete."
    ]
   },
   {
@@ -801,7 +801,7 @@
    "source": [
     "# Get the job URL, and stream the job logs.\n",
     "# With PREMIUM Redis SKU, SKU family \"P\", and cache capacity 2,\n",
-    "# it takes approximately 3-4 minutes to complete.\n",
+    "# it takes approximately 5 minutes to complete.\n",
     "fs_client.jobs.stream(poller.result().job_id)"
    ]
   },
@@ -882,10 +882,7 @@
     "import time\n",
     "\n",
     "# Initialize the online store client.\n",
-    "init_online_lookup(features, AzureMLOnBehalfOfCredential())\n",
-    "\n",
-    "# It may take 5 - 10 sec the local RPC server of online store client to be ready.\n",
-    "time.sleep(5)"
+    "init_online_lookup(features, AzureMLOnBehalfOfCredential())"
    ]
   },
   {

--- a/sdk/python/featurestore_sample/project/fraud_model/online_inference/src/scoring.py
+++ b/sdk/python/featurestore_sample/project/fraud_model/online_inference/src/scoring.py
@@ -45,8 +45,6 @@ def init():
 
     init_online_lookup(features, credential)
 
-    time.sleep(20)
-
     logging.info("Init complete")
 
 


### PR DESCRIPTION
Removed time.sleep() after init_online_lookup() in online feature store samples.

# Description


# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
