### PR TITLE
Fixes to FT text-classification

### DIFF
--- a/sdk/python/foundation-models/system/finetune/text-classification/emotion-detection.ipynb
+++ b/sdk/python/foundation-models/system/finetune/text-classification/emotion-detection.ipynb
@@ -364,7 +364,7 @@
    "outputs": [],
    "source": [
     "# save 10% of the rows from the train, validation and test dataframes into files with small_ prefix in the ./emotion-dataset folder\n",
-    "frac = 1\n",
+    "frac = 0.1\n",
     "train_df.sample(frac=frac).to_json(\n",
     "    \"./emotion-dataset/small_train.jsonl\", orient=\"records\", lines=True\n",
     ")\n",
@@ -731,7 +731,7 @@
    "source": [
     "# create a json object with the key as \"inputs\" and value as a list of values from the text column of the test dataframe\n",
     "test_df_copy = test_df[[\"text\"]]\n",
-    "test_json = {\"input_data\": test_df_copy.to_dict(\"split\")}\n",
+    "test_json = {\"inputs\": {\"text\": list(test_df_copy[\"text\"])}}\n",
     "# save the json object to a file named sample_score.json in the ./emotion-dataset folder\n",
     "with open(\"./emotion-dataset/sample_score.json\", \"w\") as f:\n",
     "    json.dump(test_json, f)"


### PR DESCRIPTION
# Description

Fixes two issues:

1. Using only 10% of dataset for small dataset (as the notebook comment mentions).
2. Request body format of sample score file used to invoke the online deployment. Request with the existing format (input_data) failed for me with the server error mentioning that "inputs" format should be used. My azure-ai-ml pkg version for reference: 1.9.0

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
