### PR TITLE
Change feature store notebook to use a different cluster name

### DIFF
--- a/sdk/python/featurestore_sample/notebooks/sdk_only/3. Experiment and train models using features.ipynb
+++ b/sdk/python/featurestore_sample/notebooks/sdk_only/3. Experiment and train models using features.ipynb
@@ -370,7 +370,7 @@
     "from azure.ai.ml.entities import AmlCompute\n",
     "\n",
     "cluster_basic = AmlCompute(\n",
-    "    name=\"cpu-cluster\",\n",
+    "    name=\"cpu-cluster-fs\",\n",
     "    type=\"amlcompute\",\n",
     "    size=\"STANDARD_F4S_V2\",  # you can replace it with other supported VM SKUs\n",
     "    location=ws_client.workspaces.get(ws_client.workspace_name).location,\n",


### PR DESCRIPTION

# Description
Change feature store notebook to use a different cluster name to avoid updating the main cpu-cluster.
(This sample was setting max_instances to 1 on cpu-cluster, which cause other samples to fail)

# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
