### PR TITLE
fix: Pin packages in `sdk/python/dev-requirements.txt`

### DIFF
--- a/sdk/python/dev-requirements.txt
+++ b/sdk/python/dev-requirements.txt
@@ -1,13 +1,13 @@
 # required for notebook testing in workflow actions
 # pinned to avoid surprises
-ipython-genutils
+ipython-genutils==0.2.0
 ipykernel==5.5.5
 papermill==2.3.3
-pandas
-matplotlib
-torch
-tensorflow
-tensorflow-hub
-transformers
+pandas==2.0.3
+matplotlib==3.7.3
+torch==2.1.0
+tensorflow==2.9.3
+tensorflow-hub==0.15.0
+transformers==4.34.0
 keras==2.9
 jupyter-client==7.4.9


### PR DESCRIPTION
# Description

`pip`'s version resolver (2020-resolver ?) will sometimes download many versions of a package to find one that satisfies installation constraints. This is usually just incurs a time cost since python packages are usually small, but this was problematic since packages like `tensorflow`, many `nvidia` packages, `pytorch`, etc... are 500MB+.

Pinning known compatible versions prevents `pip` from doing this search, and stops us from [bumping up against the 14GB storage limit in Github Actions](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
