### PR TITLE
docs: Add missing word from README.md heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ We also offer some examples for our SDKs in other languages:
 * .NET: [`sdk/dotnet`][azureml dotnet sdk v2 examples]
 * TypeScript: [`sdk/typescript`][azureml typescript sdk v2 examples]
 
-### Azure Machine Extension for Azure CLI
+### Azure Machine Learning extension for Azure CLI
 
 The [`cli/` folder][azureml cli extension examples] hosts our examples to use the
-[Azure Machine Learning Extension][azure cli ml extension v2 overview] for [Azure CLI][azure cli overview].
+[Azure Machine Learning extension][azure cli ml extension v2 overview] for [Azure CLI][azure cli overview].
 
 _Note_: If you're looking for examples that submit Azure ML jobs that run non-Python code, see:
 
@@ -41,7 +41,7 @@ _Note_: If you're looking for examples that submit Azure ML jobs that run non-Py
 
 - [Azure Machine Learning Documentation](https://docs.microsoft.com/azure/machine-learning)
 - [AzureML Python SDK v2 Overview]
-- [Azure CLI ml extension v2 Overview]
+- [Azure CLI ML extension v2 Overview]
 
 ## Contributing
 


### PR DESCRIPTION
# Description

This pull request is a follow up to #2697 which adds a missing word from a heading in the README.

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
