### PR TITLE
add import for the doc

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -432,8 +432,8 @@
    },
    "outputs": [],
    "source": [
-    "from azure.ai.ml import Input  # Add this import\n",
-    "from azure.ai.ml.constants import AssetTypes  # Add this import\n",
+    "from azure.ai.ml import Input\n",
+    "from azure.ai.ml.constants import AssetTypes\n",
     "\n",
     "# Training MLTable defined locally, with local data to be uploaded\n",
     "my_training_data_input = Input(type=AssetTypes.MLTABLE, path=training_mltable_path)\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -432,6 +432,9 @@
    },
    "outputs": [],
    "source": [
+    "from azure.ai.ml import Input  # Add this import\n",
+    "from azure.ai.ml.constants import AssetTypes  # Add this import\n",
+    "\n",
     "# Training MLTable defined locally, with local data to be uploaded\n",
     "my_training_data_input = Input(type=AssetTypes.MLTABLE, path=training_mltable_path)\n",
     "\n",


### PR DESCRIPTION
Hello, a code snippet of a notebook called [automl-image-instance-segmentation-task-fridge-items.ipynb](https://github.com/Azure/azureml-examples/blob/main/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb) is used in one of the documentation. [That one](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-auto-train-image-models?view=azureml-api-2&tabs=python#consume-data). However if we read the documentation we don't see where  `Input` and `AssetTypes` come from. So I was wondering if we could add this import in the cell being used by the documentation.