### PR TITLE
Brianhu/werkzeug

### DIFF
--- a/cli/endpoints/online/managed/inference-schema/env.yml
+++ b/cli/endpoints/online/managed/inference-schema/env.yml
@@ -10,3 +10,4 @@ dependencies:
     - joblib
     - azureml-inference-server-http==0.7.6
     - inference-schema==1.4
+    - Werkzeug==2.2.2

--- a/cli/endpoints/online/managed/openapi/env.yml
+++ b/cli/endpoints/online/managed/openapi/env.yml
@@ -10,3 +10,4 @@ dependencies:
     - joblib
     - azureml-inference-server-http==0.7.6
     - inference-schema==1.4
+    - Werkzeug==2.2.2

--- a/cli/endpoints/online/model-1/environment/conda.yaml
+++ b/cli/endpoints/online/model-1/environment/conda.yaml
@@ -11,4 +11,3 @@ dependencies:
     - azureml-defaults==1.53.0
     - inference-schema[numpy-support]==1.5.1
     - joblib==1.2.0
-    - Werkzeug==2.2.2

--- a/cli/endpoints/online/model-1/environment/conda.yaml
+++ b/cli/endpoints/online/model-1/environment/conda.yaml
@@ -11,3 +11,4 @@ dependencies:
     - azureml-defaults==1.53.0
     - inference-schema[numpy-support]==1.5.1
     - joblib==1.2.0
+    - Werkzeug==2.2.2


### PR DESCRIPTION
# Description

Looks like a recent upgrade to Werkzeug 3.x caused a breaking back-compatibility change [python - ImportError: cannot import name 'url_quote' from 'werkzeug.urls' - Stack Overflow](https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls)

Solution: Just set a fix version for Werkzeug such as Werkzeug==2.2.2 in your requirements.txt and it should work.

Verified w/ reproduction of error:
![image](https://github.com/Azure/azureml-examples/assets/24861524/fd11a149-b625-4fe4-829a-ce75a39659dd)


# Checklist

- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
