### PR TITLE
Pin scikit-learn version to 1.2.2 to fix moe example version mismatch issue

### DIFF
--- a/cli/endpoints/online/managed/inference-schema/env.yml
+++ b/cli/endpoints/online/managed/inference-schema/env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - scikit-learn
+  - scikit-learn=1.2.2
   - numpy
   - pandas
   - pip:


### PR DESCRIPTION

A last week's change https://github.com/Azure/azureml-examples/pull/2822#event-10957902305 unpinned scikit-learn version and caused cli-scripts-deploy-moe-inference-schema failing with version mismatch issue, revert unpin in this PR to fix.
![image](https://github.com/Azure/azureml-examples/assets/36549163/f9014a8a-48c3-4730-be46-6cd3044e75d0)
![image](https://github.com/Azure/azureml-examples/assets/36549163/31ee59a6-215c-4054-8483-bcfd455ea3fb)
# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
