### PR TITLE
Add new warning to the ignore list

### DIFF
--- a/.github/test/scripts/check_notebook_output.py
+++ b/.github/test/scripts/check_notebook_output.py
@@ -75,6 +75,8 @@ allowed_list = [
     "save_mlflow is an internal parameter",
     "start_auxiliary_runs_before_parent_complete is an internal parameter",
     "Detected ",
+    "FutureWarning: promote has been superseded by mode",
+    "dataframe_reader.complete_incoming_dataframe",
 ]
 
 with open(full_name, "r") as notebook_file:


### PR DESCRIPTION
# Description
The orange juice and bike share notebooks are failing because of a new warning. We are adding them to the ignore list here.
See work item: 2827640

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
