### PR TITLE
[AutoML] increasing timeout for image classification multilabel

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
@@ -725,7 +725,7 @@
     "    target_column_name=\"label\",\n",
     ")\n",
     "\n",
-    "image_classification_multilabel_job.set_limits(timeout_minutes=60)\n",
+    "image_classification_multilabel_job.set_limits(timeout_minutes=70)\n",
     "\n",
     "image_classification_multilabel_job.set_training_parameters(\n",
     "    model_name=\"microsoft/beit-base-patch16-224-pt22k-ft22k\"\n",


### PR DESCRIPTION
# Description
[AutoML] increasing timeout for image classification multilabel. The workflows have been failing intermittently, in cases where the run exceeds few minutes over 60 minutes. 

Failed workflow: https://github.com/Azure/azureml-examples/actions/runs/7056135845

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
