### PR TITLE
ci: Allow bootstrapping-infra to continue past acr permission grant error

### DIFF
--- a/infra/bootstrapping/bootstrap.sh
+++ b/infra/bootstrapping/bootstrap.sh
@@ -83,7 +83,12 @@ if [[ ! -z "${RUN_BOOTSTRAP:-}" ]]; then
     "$SCRIPT_DIR"/sdk_helpers.sh ensure_vnet "vnet-mevnet"
     "$SCRIPT_DIR"/sdk_helpers.sh ensure_subnet "vnet-mevnet" "snet-scoring"
     "$SCRIPT_DIR"/sdk_helpers.sh ensure_identity "uaimevnet"
-    "$SCRIPT_DIR"/sdk_helpers.sh grant_permission_identity_on_acr "uaimevnet"
+
+    (
+      # TODO: Figure out why this sometimes fails
+      #       Currently errors out and prevents script from running
+      "$SCRIPT_DIR"/sdk_helpers.sh grant_permission_identity_on_acr "uaimevnet"
+    ) || :
 
     echo_title "Ensuring Permissions on RG"
     "$SCRIPT_DIR"/sdk_helpers.sh grant_permission_app_id_on_rg "${APP_NAME}"


### PR DESCRIPTION
# Description

The bootstrapping-infra workflow currently has an issue where trying to grant a managed identity permission to an acr will fail, and prevent the rest of the script from proceeding:

https://github.com/Azure/azureml-examples/blob/8c1f321dfed8f557c38a7d27dd8b6ae28602ce3a/infra/bootstrapping/bootstrap.sh#L86

This PR allows the script to continue on error, while a root cause is found

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
