### PR TITLE
Add notebook and pipelines for Claude and OpenAI LLM evaluations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -243,7 +243,10 @@
 /sdk/python/featurestore_sample/notebooks/sdk_only/2.\ Experiment\ and\ train\ models\ using\ features.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1  
 /sdk/python/featurestore_sample/notebooks/sdk_only/3.\ Enable\ recurrent\ materialization\ and\ run\ batch\ inference.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1  
 /sdk/python/featurestore_sample/notebooks/sdk_only/4.\ Enable\ online\ store\ and\ run\ online\ inference.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1  
-/sdk/python/featurestore_sample/notebooks/sdk_only/5.\ Develop\ a\ feature\ set\ with\ custom\ source.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1  
+/sdk/python/featurestore_sample/notebooks/sdk_only/5.\ Develop\ a\ feature\ set\ with\ custom\ source.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1
+/sdk/python/foundation-models/benchmarking/evaluating_claude_models.ipynb @arun-rajora
+/sdk/python/foundation-models/benchmarking/evaluating_oai_models.ipynb @arun-rajora
+/sdk/python/foundation-models/benchmarking/evaluation_pipelines/* @arun-rajora  
 /sdk/python/jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing-serverless.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1  
 /sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1  
 /sdk/python/jobs/configuration.ipynb @sdgilley @msakande @Blackmist @ssalgadodev @lgayhardt @fbsolo-ms1  

--- a/sdk/python/foundation-models/benchmarking/evaluating_claude_models.ipynb
+++ b/sdk/python/foundation-models/benchmarking/evaluating_claude_models.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c90af50b-a3a3-42ea-b855-943777df2bee",
+   "metadata": {},
+   "source": [
+    "# Evaluating Claude models with AzureML\n",
+    "\n",
+    "In this notebook, you will learn how to run evaluations of Anthropic's Claude model using the AzureML SDK. Along with this notebook, we've included a preconfigured set of 12 evaluations using well-known, public datasets (e.g., MMLU, HellaSwag, Winogrande).\n",
+    "\n",
+    "Please see the [Azure AI Leaderboard](https://ai.azure.com/explore/leaderboard) for other supported model benchmarks and for more details on the eval datasets.\n",
+    "\n",
+    "*Disclaimer: This notebook has been tested against AWS Bedrock endpoints for Claude 2.1. Other deployments or model versions are not guaranteed to work with the evaluation pipelines distributed with this notebook.*  \n",
+    "\n",
+    "## Prerequistes\n",
+    "- An Azure account with an active subscription - [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F)\n",
+    "- An Azure ML workspace - [Configure workspace](../../configuration.ipynb)\n",
+    "- Installed Azure Machine Learning Python SDK v2 - [install instructions](../../../README.md) - check the getting started section\n",
+    "- A python environment with [mlflow](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-use-mlflow-configure-tracking?view=azureml-api-2&tabs=python%2Cmlflow) for retrieving eval metrics\n",
+    "- Access keys for Claude endpoints on [Amazon Web Services Bedrock platform](https://aws.amazon.com/bedrock/claude/)  \n",
+    "\n",
+    "## Configuring a Workspace connection for Bedrock access\n",
+    "You will use a Workspace connection to securely store Bedrock access keys. Follow the steps below to create a custom-type connection:\n",
+    "- Follow directions for [creating a custom connection in the AzureML studio UI](https://learn.microsoft.com/en-us/azure/machine-learning/prompt-flow/tools-reference/python-tool?view=azureml-api-2#create-a-custom-connection)\n",
+    "- Add the following two key-value pairs to the custom connection:\n",
+    "  1. A key named `AccessKey` with a value containing your AWS access key\n",
+    "  2. A key named `SecretKey` with a value containing your AWS secret access key \n",
+    "\n",
+    "## Configuring and running an evaluation pipeline\n",
+    "Please set global values in the following cell for your AzureML Workspace, the Bedrock endpoint you want to call, the name of connection you created in the previous step, and the name of the eval you want to run.\n",
+    "\n",
+    "Supported evals are the following: `boolq`, `gsm8k`, `hellaswag`, `human_eval`, `mmlu_humanities`, `mmlu_other`, `mmlu_social_sciences`, `mmlu_stem`, `openbookqa`, `piqa`, `social_iqa`, `winogrande`.\n",
+    "\n",
+    "Note that evaluation pipelines automatically download relevant datasets from public sources. For `human_eval`, models are prompted to generate Python code that is exectued in the pipeline to measure coding capabilities of the model.\n",
+    "\n",
+    "You can also set the sample ratio, the fraction of the selected dataset to run for the eval.\n",
+    "\n",
+    "**Warning**: Many datasets contain thousands of examples which can lead to high endpoint usage costs. We advise starting with a small sample ratio (e.g., 1%) to verify the pipeline and then increasing the ratio if desired. Note that benchmark metrics obtained with small sample ratios may not be comparable between different models. Please use sample_ratio=1 for model comparisons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ce3f8a4-ce03-462b-89fa-19cac827c30c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# AzureML settings - please fill in your values\n",
+    "subscription_id = \"<Azure subscription ID>\"\n",
+    "resource_group = \"<Resource group>\"\n",
+    "workspace_name = \"<Workspace name\"\n",
+    "experiment_name = \"<Experiment name>\"\n",
+    "\n",
+    "# Eval to run - you can change this to any of the 12 supported eval names\n",
+    "# Supported evals: boolq, gsm8k, hellaswag, human_eval, mmlu_humanities, mmlu_other, mmlu_social_sciences, mmlu_stem, openbookqa, piqa, social_iqa, winogrande\n",
+    "eval_name = \"mmlu_humanities\"\n",
+    "\n",
+    "# Bedrock URL - defaults to Claude 2.1 in us-east-1\n",
+    "bedrock_endpoint_url = (\n",
+    "    \"https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke\"\n",
+    ")\n",
+    "\n",
+    "# Name of the connection in your Workspace storing AWS access keys\n",
+    "connection_name = \"<Connection name>\"\n",
+    "\n",
+    "# Sample ratio - what fraction of the dataset to run for the eval?\n",
+    "# **WARNING** be aware of endpoint costs!\n",
+    "sample_ratio = 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2cdbe9be-df54-4035-b7a6-f6f8677f16dc",
+   "metadata": {},
+   "source": [
+    "Run the following cell to get an `MLClient` for communicating with your Workspace:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25f47da9-5c31-4729-a233-cece290415f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azure.identity import DefaultAzureCredential\n",
+    "from azure.ai.ml import MLClient\n",
+    "\n",
+    "# client for AzureML Workspace actions\n",
+    "ml_client = MLClient(\n",
+    "    credential=DefaultAzureCredential(),\n",
+    "    subscription_id=subscription_id,\n",
+    "    resource_group_name=resource_group,\n",
+    "    workspace_name=workspace_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e4bfaa2-fd99-4850-a9c4-8838c4ef9313",
+   "metadata": {},
+   "source": [
+    "The code in the next cell launches the evaluation pipeline job using [serverless compute](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-use-serverless-compute) by default. You can optionally [create your own compute cluster](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-attach-compute-cluster) and use it to execute the job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e4c5468-7585-481e-bb20-ad91373cac6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azure.ai.ml import load_job\n",
+    "\n",
+    "# load the pipeline from the yaml def\n",
+    "pipeline_job = load_job(f\"./evaluation_pipelines/claude-2_1/{eval_name}.yaml\")\n",
+    "\n",
+    "# Set pipeline job inputs\n",
+    "pipeline_job.inputs.endpoint_url = bedrock_endpoint_url\n",
+    "pipeline_job.inputs.ws_connection_name = connection_name\n",
+    "pipeline_job.inputs.sample_ratio = sample_ratio\n",
+    "\n",
+    "# Optionally use your own compute cluster\n",
+    "# pipeline_job.settings.default_compute = \"<Your compute cluster name>\"\n",
+    "\n",
+    "# Start the job in the Workspace\n",
+    "returned_job = ml_client.jobs.create_or_update(\n",
+    "    pipeline_job, experiment_name=experiment_name\n",
+    ")\n",
+    "returned_job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "095005d9-1deb-4097-a718-4059a335ec09",
+   "metadata": {},
+   "source": [
+    "Run the next cell to stream the job. Notebook execution will be paused until the job finishes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1376aa46-725d-4d6c-8725-3a2d4d52bdfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Wait until the job completes\n",
+    "ml_client.jobs.stream(returned_job.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07fa2c79-f875-4c4f-8f09-37158b56bdcd",
+   "metadata": {},
+   "source": [
+    "## Retrieve accuracy scores from the run\n",
+    "When the pipeline finishes, you can retrieve evaluation metrics from the run via mlflow. The primary measure of accuracy for the evals is `mean_exact_match`, with the exception of human_eval which uses `pass@1`. \n",
+    "\n",
+    "Mean exact match is the proportion of model predictions that exactly match the corresponding correct answers. Thus, it is applicable to question answering evaluations that are multiple choice or have a single, correct answer. The pass@1 metric is used for evaluating code generation and is the proportion of model generated code solutions that pass a set of unit tests given in the eval dataset. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "299bf8ea-49ab-44c3-96e6-51902fa03df4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mlflow\n",
+    "\n",
+    "accuracy_metric_name = \"mean_exact_match\" if eval_name != \"human_eval\" else \"pass@1\"\n",
+    "\n",
+    "mlflow_tracking_uri = ml_client.workspaces.get(\n",
+    "    ml_client.workspace_name\n",
+    ").mlflow_tracking_uri\n",
+    "mlflow.set_tracking_uri(mlflow_tracking_uri)\n",
+    "\n",
+    "run = mlflow.get_run(run_id=returned_job.name)\n",
+    "metric_val = run.data.metrics[accuracy_metric_name]\n",
+    "\n",
+    "if sample_ratio < 1.0:\n",
+    "    print(\n",
+    "        f\"**Warning** sample_ratio is {sample_ratio}. Use sample_ratio=1.0 when comparing metrics between models.\"\n",
+    "    )\n",
+    "\n",
+    "print(f\"Eval: {eval_name}\")\n",
+    "print(f\"Sample ratio: {sample_ratio}\")\n",
+    "print(f\"Accuracy metric name: {accuracy_metric_name}\")\n",
+    "print(f\"Accuracy metric value: {metric_val}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sdk/python/foundation-models/benchmarking/evaluating_oai_models.ipynb
+++ b/sdk/python/foundation-models/benchmarking/evaluating_oai_models.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c90af50b-a3a3-42ea-b855-943777df2bee",
+   "metadata": {},
+   "source": [
+    "# Evaluating OpenAI models with AzureML\n",
+    "\n",
+    "In this notebook, you will learn how to run evaluations of OpenAI's GPT models using the AzureML SDK. Along with this notebook, we've included a preconfigured set of 12 evaluations using well-known, public datasets (e.g., MMLU, HellaSwag, Winogrande).\n",
+    "\n",
+    "Please see the [Azure AI Leaderboard](https://ai.azure.com/explore/leaderboard) for other supported model benchmarks and for more details on the eval datasets.\n",
+    "\n",
+    "*Disclaimer: This notebook has been tested against Azure OpenAI endpoints for GPT-4-0613. Other deployments or model versions are not guaranteed to work with the evaluation pipelines distributed with this notebook.*  \n",
+    "\n",
+    "## Prerequistes\n",
+    "- An Azure account with an active subscription - [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F)\n",
+    "- An Azure ML workspace - [Configure workspace](../../configuration.ipynb)\n",
+    "- An OpenAI model deployment in the Azure OpenAI service - [Create and deploy an Azure OpenAI Service resource](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource)\n",
+    "- Installed Azure Machine Learning Python SDK v2 - [install instructions](../../../README.md) - check the getting started section\n",
+    "- A python environment with [mlflow](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-use-mlflow-configure-tracking?view=azureml-api-2&tabs=python%2Cmlflow) for retrieving eval metrics\n",
+    "\n",
+    "## Configuring a Workspace connection for Azure OpenAI access\n",
+    "You will use a Workspace connection to securely store OpenAI access keys. Follow the directions for [creating an AOAI connection in the AzureML studio UI](https://learn.microsoft.com/en-us/azure/machine-learning/prompt-flow/get-started-prompt-flow?view=azureml-api-2#connection).\n",
+    "\n",
+    "## Configuring and running an evaluation pipeline\n",
+    "Please set global values in the following cell for your AzureML Workspace, the Azure OpenAI endpoint you want to call, the name of connection you created in the previous step, and the name of the eval you want to run.\n",
+    "\n",
+    "Supported evals are the following: `boolq`, `gsm8k`, `hellaswag`, `human_eval`, `mmlu_humanities`, `mmlu_other`, `mmlu_social_sciences`, `mmlu_stem`, `openbookqa`, `piqa`, `social_iqa`, `winogrande`.\n",
+    "\n",
+    "Note that evaluation pipelines automatically download relevant datasets from public sources. For `human_eval`, models are prompted to generate Python code that is exectued in the pipeline to measure coding capabilities of the model.\n",
+    "\n",
+    "You can also set the sample ratio, the fraction of the selected dataset to run for the eval.\n",
+    "\n",
+    "**Warning**: Many datasets contain thousands of examples which can lead to high endpoint usage costs. We advise starting with a small sample ratio (e.g., 1%) to verify the pipeline and then increasing the ratio if desired. Note that benchmark metrics obtained with small sample ratios may not be comparable between different models. Please use sample_ratio=1 for model comparisons. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ce3f8a4-ce03-462b-89fa-19cac827c30c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# AzureML settings - please fill in your values\n",
+    "subscription_id = \"<Azure subscription ID>\"\n",
+    "resource_group = \"<Resource group>\"\n",
+    "workspace_name = \"<Workspace name\"\n",
+    "experiment_name = \"<Experiment name>\"\n",
+    "\n",
+    "# Eval to run - you can change this to any of the 12 supported eval names\n",
+    "# Supported evals: boolq, gsm8k, hellaswag, human_eval, mmlu_humanities, mmlu_other, mmlu_social_sciences, mmlu_stem, openbookqa, piqa, social_iqa, winogrande\n",
+    "eval_name = \"mmlu_humanities\"\n",
+    "\n",
+    "# AOAI endpoint URL, ex: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview\n",
+    "aoai_endpoint_url = \"<Endpoint URL>\"\n",
+    "\n",
+    "# Name of the connection in your Workspace storing AOAI access keys\n",
+    "connection_name = \"<Connection name>\"\n",
+    "\n",
+    "# Sample ratio - what fraction of the dataset to run for the eval?\n",
+    "# **WARNING** be aware of endpoint costs!\n",
+    "sample_ratio = 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2cdbe9be-df54-4035-b7a6-f6f8677f16dc",
+   "metadata": {},
+   "source": [
+    "Run the following cell to get an `MLClient` for communicating with your Workspace:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25f47da9-5c31-4729-a233-cece290415f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azure.identity import DefaultAzureCredential\n",
+    "from azure.ai.ml import MLClient\n",
+    "\n",
+    "# client for AzureML Workspace actions\n",
+    "ml_client = MLClient(\n",
+    "    credential=DefaultAzureCredential(),\n",
+    "    subscription_id=subscription_id,\n",
+    "    resource_group_name=resource_group,\n",
+    "    workspace_name=workspace_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e4bfaa2-fd99-4850-a9c4-8838c4ef9313",
+   "metadata": {},
+   "source": [
+    "The code in the next cell launches the evaluation pipeline job using [serverless compute](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-use-serverless-compute) by default. You can optionally [create your own compute cluster](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-attach-compute-cluster) and use it to execute the job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e4c5468-7585-481e-bb20-ad91373cac6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azure.ai.ml import load_job\n",
+    "\n",
+    "# load the pipeline from the yaml def\n",
+    "pipeline_job = load_job(f\"./evaluation_pipelines/azure_openai/{eval_name}.yaml\")\n",
+    "\n",
+    "# Set pipeline job inputs\n",
+    "pipeline_job.inputs.endpoint_url = aoai_endpoint_url\n",
+    "pipeline_job.inputs.ws_connection_name = connection_name\n",
+    "pipeline_job.inputs.sample_ratio = sample_ratio\n",
+    "\n",
+    "# Optionally use your own compute cluster\n",
+    "# pipeline_job.settings.default_compute = \"<Your compute cluster name>\"\n",
+    "\n",
+    "# Start the job in the Workspace\n",
+    "returned_job = ml_client.jobs.create_or_update(\n",
+    "    pipeline_job, experiment_name=experiment_name\n",
+    ")\n",
+    "returned_job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "095005d9-1deb-4097-a718-4059a335ec09",
+   "metadata": {},
+   "source": [
+    "Run the next cell to stream the job. Notebook execution will be paused until the job finishes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1376aa46-725d-4d6c-8725-3a2d4d52bdfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Wait until the job completes\n",
+    "ml_client.jobs.stream(returned_job.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07fa2c79-f875-4c4f-8f09-37158b56bdcd",
+   "metadata": {},
+   "source": [
+    "## Retrieve accuracy scores from the run\n",
+    "When the pipeline finishes, you can retrieve evaluation metrics from the run via mlflow. The primary measure of accuracy for the evals is `mean_exact_match`, with the exception of human_eval which uses `pass@1`. \n",
+    "\n",
+    "Mean exact match is the proportion of model predictions that exactly match the corresponding correct answers. Thus, it is applicable to question answering evaluations that are multiple choice or have a single, correct answer. The pass@1 metric is used for evaluating code generation and is the proportion of model generated code solutions that pass a set of unit tests given in the eval dataset. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "299bf8ea-49ab-44c3-96e6-51902fa03df4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mlflow\n",
+    "\n",
+    "accuracy_metric_name = \"mean_exact_match\" if eval_name != \"human_eval\" else \"pass@1\"\n",
+    "\n",
+    "mlflow_tracking_uri = ml_client.workspaces.get(\n",
+    "    ml_client.workspace_name\n",
+    ").mlflow_tracking_uri\n",
+    "mlflow.set_tracking_uri(mlflow_tracking_uri)\n",
+    "\n",
+    "run = mlflow.get_run(run_id=returned_job.name)\n",
+    "metric_val = run.data.metrics[accuracy_metric_name]\n",
+    "\n",
+    "if sample_ratio < 1.0:\n",
+    "    print(\n",
+    "        f\"**Warning** sample_ratio is {sample_ratio}. Use sample_ratio=1.0 when comparing metrics between models.\"\n",
+    "    )\n",
+    "\n",
+    "print(f\"Eval: {eval_name}\")\n",
+    "print(f\"Sample ratio: {sample_ratio}\")\n",
+    "print(f\"Accuracy metric name: {accuracy_metric_name}\")\n",
+    "print(f\"Accuracy metric value: {metric_val}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/boolq.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/boolq.yaml
@@ -1,0 +1,211 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: boolq_aoai
+description: Azure OpenAI eval on BoolQ
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: boolq
+      configuration: all
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": true,\n  \"\
+        answerB\": false,\n  \"context\": {{passage}},\n  \"target\": {{answer}}\n\
+        }"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: boolq
+      configuration: all
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": true,\n  \"\
+        answerB\": false,\n  \"context\": {{passage}},\n  \"target\": {{answer}}\n\
+        }"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: "Given the context answer the question: context: {{context}}\n\
+        \ question:{{question}}\n 1.: {{answerA}}\n 2.: {{answerB}}\nAnswer:"
+      n_shots: 5
+      output_pattern: ' {{target}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      find_first: True,False
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/gsm8k.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/gsm8k.yaml
@@ -1,0 +1,208 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: gsm8k_aoai
+description: Azure OpenAI eval on GSM8k with chain-of-thought prompting
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 300, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: gsm8k
+      configuration: main
+      split: test
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\":{{question}},\n  \"solution\":{{answer.split(\"\
+        \ ####\")[0]}},\n  \"answer\":{{answer.split(\"#### \")[-1]|string}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: fewshot
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/gsm8k_static_shots.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\":{{question}},\n  \"solution\":{{answer.split(\"\
+        \ ####\")[0]}},\n  \"answer\":{{answer.split(\"#### \")[-1]|string}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: 'Q: {{question}}
+
+        A:'
+      n_shots: 8
+      output_pattern: '{{solution}} The answer is {{answer}}.'
+      system_message: When answering the question, please ensure that the last number
+        you write in the response is the correct, numerical answer to the question.
+      random_seed: 0
+      ground_truth_column_name: answer
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: ground_truth
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: ground_truth
+      prediction_column_name: prediction
+      extract_number: last
+      strip_characters: .
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: ground_truth
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\.0+$", ","]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/hellaswag.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/hellaswag.yaml
@@ -1,0 +1,226 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: hellaswag_aoai
+description: Azure OpenAI eval on HellaSwag
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: hellaswag
+      configuration: all
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"activity_label\": {{activity_label}},\n  {% for i in\
+        \ range(endings|length) %}\n    \"choice_{{(i+1)}}\": {{endings[i]}},\n  {%\
+        \ endfor %}\n  \"ctx\": {{ctx}},\n  {% set label_int = label | int %}\n  \"\
+        label\": {{(label_int + 1)}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: hellaswag
+      configuration: all
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"activity_label\": {{activity_label}},\n  {% for i in\
+        \ range(endings|length) %}\n    \"choice_{{(i+1)}}\": {{endings[i]}},\n  {%\
+        \ endfor %}\n  \"ctx\": {{ctx}},\n  {% set label_int = label | int %}\n  \"\
+        label\": {{(label_int + 1)}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: 'Category: {{activity_label}}
+
+        Text: {{ctx}}
+
+        Completion options:
+
+        (1) {{choice_1}}
+
+        (2) {{choice_2}}
+
+        (3) {{choice_3}}
+
+        (4) {{choice_4}}
+
+        The most likely text completion is: '
+      n_shots: 5
+      output_pattern: '{{label}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      find_first: 1,2,3,4
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/human_eval.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/human_eval.yaml
@@ -1,0 +1,157 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: human_eval_aoai
+description: Azure OpenAI eval on HumanEval
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 500, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: openai_humaneval
+      split: test
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\"task_id\":{{task_id}}, \n\"prompt\": {{prompt}}}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: '{{prompt}}'
+      n_shots: 0
+      output_pattern: '{{task_id}}'
+      system_message: You are an AI Python assistant. You will be given a partial
+        implementation of a function. Write your full implementation (restate the
+        function signature).
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: text-generation
+      ground_truth_column_name: ',ground_truth'
+      prediction_column_name: prediction
+      evaluation_config_params: '{"sub_task": "code"}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_humanities.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_humanities.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_humanities_aoai
+description: Azure OpenAI eval on MMLU Humanities
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: formal_logic,high_school_european_history,high_school_us_history,high_school_world_history,international_law,jurisprudence,logical_fallacies,moral_disputes,moral_scenarios,philosophy,prehistory,professional_law,world_religions
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: formal_logic,high_school_european_history,high_school_us_history,high_school_world_history,international_law,jurisprudence,logical_fallacies,moral_disputes,moral_scenarios,philosophy,prehistory,professional_law,world_religions
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: '### Question: {{question}}
+
+        A. {{choices[0]}}
+
+        B. {{choices[1]}}
+
+        C. {{choices[2]}}
+
+        D. {{choices[3]}}
+
+        ###Answer:'
+      n_shots: 5
+      output_pattern: ' {{answer}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      find_first: A,B,C,D
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_other.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_other.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_other_aoai
+description: Azure OpenAI eval on MMLU Other
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: business_ethics,clinical_knowledge,college_medicine,global_facts,human_aging,management,marketing,medical_genetics,miscellaneous,nutrition,professional_accounting,professional_medicine,virology
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: business_ethics,clinical_knowledge,college_medicine,global_facts,human_aging,management,marketing,medical_genetics,miscellaneous,nutrition,professional_accounting,professional_medicine,virology
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: '### Question: {{question}}
+
+        A. {{choices[0]}}
+
+        B. {{choices[1]}}
+
+        C. {{choices[2]}}
+
+        D. {{choices[3]}}
+
+        ###Answer:'
+      n_shots: 5
+      output_pattern: ' {{answer}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      find_first: A,B,C,D
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_social_sciences.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_social_sciences.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_social_sciences_aoai
+description: Azure OpenAI eval on MMLU Social Sciences
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: econometrics,high_school_geography,high_school_government_and_politics,high_school_macroeconomics,high_school_microeconomics,high_school_psychology,human_sexuality,professional_psychology,public_relations,security_studies,sociology,us_foreign_policy
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: econometrics,high_school_geography,high_school_government_and_politics,high_school_macroeconomics,high_school_microeconomics,high_school_psychology,human_sexuality,professional_psychology,public_relations,security_studies,sociology,us_foreign_policy
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: '### Question: {{question}}
+
+        A. {{choices[0]}}
+
+        B. {{choices[1]}}
+
+        C. {{choices[2]}}
+
+        D. {{choices[3]}}
+
+        ###Answer:'
+      n_shots: 5
+      output_pattern: ' {{answer}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      find_first: A,B,C,D
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_stem.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/mmlu_stem.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_stem_aoai
+description: Azure OpenAI eval on MMLU STEM
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: abstract_algebra,anatomy,astronomy,college_biology,college_chemistry,college_computer_science,college_mathematics,college_physics,computer_security,conceptual_physics,electrical_engineering,elementary_mathematics,high_school_biology,high_school_chemistry,high_school_computer_science,high_school_mathematics,high_school_physics,high_school_statistics,machine_learning
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: abstract_algebra,anatomy,astronomy,college_biology,college_chemistry,college_computer_science,college_mathematics,college_physics,computer_security,conceptual_physics,electrical_engineering,elementary_mathematics,high_school_biology,high_school_chemistry,high_school_computer_science,high_school_mathematics,high_school_physics,high_school_statistics,machine_learning
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: '### Question: {{question}}
+
+        A. {{choices[0]}}
+
+        B. {{choices[1]}}
+
+        C. {{choices[2]}}
+
+        D. {{choices[3]}}
+
+        ###Answer:'
+      n_shots: 5
+      output_pattern: ' {{answer}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      find_first: A,B,C,D
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/openbookqa.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/openbookqa.yaml
@@ -1,0 +1,223 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: openbookqa_aoai
+description: Azure OpenAI eval on OpenBookQA
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: openbookqa
+      configuration: main
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question_stem}}, "choices":{{choices.text}},
+        "answer":{{answerKey}}}'
+      encoder_config: '{"column_name": "answer", "A": 1, "B": 2, "C": 3, "D": 4}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: openbookqa
+      configuration: main
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question_stem}}, "choices":{{choices.text}},
+        "answer":{{answerKey}}}'
+      encoder_config: '{"column_name": "answer", "A": 1, "B": 2, "C": 3, "D": 4}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: 'Question: {{question}}
+
+        Answer options:
+
+        (1) {{choices[0]}}
+
+        (2) {{choices[1]}}
+
+        (3) {{choices[2]}}
+
+        (4) {{choices[3]}}
+
+        The answer is:'
+      n_shots: 10
+      output_pattern: ' {{answer}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      extract_number: first
+      strip_characters: .
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/piqa.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/piqa.yaml
@@ -1,0 +1,185 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: piqa_aoai
+description: Azure OpenAI eval on PIQA
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: piqa
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: piqa
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 0.3
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: 'Goal: {{goal}}
+
+        Answer options:
+
+        (1) {{sol1}}
+
+        (2) {{sol2}}
+
+        The answer is:'
+      n_shots: 5
+      output_pattern: ' {{ (label + 1) }}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      extract_number: first
+      strip_characters: .
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/social_iqa.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/social_iqa.yaml
@@ -1,0 +1,213 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: social_iqa_aoai
+description: Azure OpenAI eval on Social IQA
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: social_i_qa
+      configuration: all
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": {{answerA}},\n\
+        \  \"answerB\": {{answerB}},\n  \"answerC\": {{answerC}},\n  \"context\":\
+        \ {{context}},\n  \"target\": {{label}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: social_i_qa
+      configuration: all
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 0.3
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": {{answerA}},\n\
+        \  \"answerB\": {{answerB}},\n  \"answerC\": {{answerC}},\n  \"context\":\
+        \ {{context}},\n  \"target\": {{label}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: "Given the context answer the question: context: {{context}}\n\
+        \ question:{{question}}\n 1.: {{answerA}}\n 2.: {{answerB}}\n 3.: {{answerC}}\n\
+        Answer:"
+      n_shots: 5
+      output_pattern: ' {{target}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      extract_number: first
+      strip_characters: .
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/winogrande.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/azure_openai/winogrande.yaml
@@ -1,0 +1,196 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: winogrande_aoai
+description: Azure OpenAI eval on Winogrande
+inputs:
+  endpoint_url: https://resource-name.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2023-07-01-preview
+  ws_connection_name: <connection name>
+  payload_pattern: '{"messages": ###<prompt>, "temperature": 0.0, "max_tokens": 10, "top_p": 1.0, "frequency_penalty": 0.0, "presence_penalty": 0.0, "stop": null}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: winogrande
+      configuration: winogrande_xs
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: winogrande
+      configuration: winogrande_xs
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      prompt_type: chat
+      prompt_pattern: '### Text:
+
+
+        {{sentence}}
+
+
+        ### Option 1:
+
+
+        {{option1}}
+
+
+        ### Option 2:
+
+
+        {{option2}}
+
+
+        ### Answer:'
+      n_shots: 5
+      output_pattern: '{{answer}}'
+      few_shot_separator: '
+
+
+        '
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 5
+      max_worker_count: 200
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: '
+
+
+        '
+      extract_number: first
+      strip_characters: .
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/boolq.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/boolq.yaml
@@ -1,0 +1,218 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: boolq_claude
+description: Claude eval on BoolQ
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: boolq
+      configuration: all
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": true,\n  \"\
+        answerB\": false,\n  \"context\": {{passage}},\n  \"target\": {{answer}}\n\
+        }"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: boolq
+      configuration: all
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": true,\n  \"\
+        answerB\": false,\n  \"context\": {{passage}},\n  \"target\": {{answer}}\n\
+        }"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a question along with context and asked to choose whether the question is true or false. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only true or false. The answer must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\nGiven the context answer the question: context: {{context}}\n\
+      question: {{question}}\n\
+      1.: {{answerA}}\n\
+      2.: {{answerB}}\n\
+      Answer:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      Given the context answer the question: context: {{context}}\n\
+      question: {{question}}\n\
+      1.: {{answerA}}\n\
+      2.: {{answerB}}\n\
+      Answer: {{target}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: ' {{target}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"], "ignore_case": true}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/gsm8k.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/gsm8k.yaml
@@ -1,0 +1,214 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: gsm8k_claude
+description: Claude eval on GSM8k with chain-of-thought prompting
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 300, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: gsm8k
+      configuration: main
+      split: test
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\":{{question}},\n  \"solution\":{{answer.split(\"\
+        \ ####\")[0]}},\n  \"answer\":{{answer.split(\"#### \")[-1]|string}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: fewshot
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/gsm8k_static_shots.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\":{{question}},\n  \"solution\":{{answer.split(\"\
+        \ ####\")[0]}},\n  \"answer\":{{answer.split(\"#### \")[-1]|string}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to find the answer after thinking and calculating step by step. \
+      There are examples within <example> tags for you to learn from. For the last question respond \
+      with the number you calculated within the tags <answer> and </answer>. Do not add other text inside the answer tags.\n\nHuman:"
+      prompt_pattern: "\nQ: {{question}}\n\
+      A:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      Q: {{question}}\n\
+      A: {{solution}} The answer is {{answer}}.\n\
+      </example>"
+      n_shots: 8
+      output_pattern: '{{answer}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+      ground_truth_column_name: answer
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: ground_truth
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: ground_truth
+      prediction_column_name: prediction
+      separator: "Q:"
+      extract_number: last
+      strip_characters: .
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: ground_truth
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\.0+$", ","]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/hellaswag.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/hellaswag.yaml
@@ -1,0 +1,226 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: hellaswag_claude
+description: Claude eval on HellaSwag
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: hellaswag
+      configuration: all
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"activity_label\": {{activity_label}},\n  {% for i in\
+        \ range(endings|length) %}\n    \"choice_{{(i+1)}}\": {{endings[i]}},\n  {%\
+        \ endfor %}\n  \"ctx\": {{ctx}},\n  {% set label_int = label | int %}\n  \"\
+        label\": {{(label_int + 1)}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: hellaswag
+      configuration: all
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"activity_label\": {{activity_label}},\n  {% for i in\
+        \ range(endings|length) %}\n    \"choice_{{(i+1)}}\": {{endings[i]}},\n  {%\
+        \ endfor %}\n  \"ctx\": {{ctx}},\n  {% set label_int = label | int %}\n  \"\
+        label\": {{(label_int + 1)}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to choose between answers in options 1, 2, 3, or 4. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only the number of the option you choose. This number must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\nCategory: {{activity_label}}\n\
+      Text: {{ctx}}\n\
+      Completion options:\n\
+      (1) {{choice_1}}\n\
+      (2) {{choice_2}}\n\
+      (3) {{choice_3}}\n\
+      (4) {{choice_4}}\n\
+      The most likely text completion is:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      Category: {{activity_label}}\n\
+      Text: {{ctx}}\n\
+      Completion options:\n\
+      (1) {{choice_1}}\n\
+      (2) {{choice_2}}\n\
+      (3) {{choice_3}}\n\
+      (4) {{choice_4}}\n\
+      The most likely text completion is: {{label}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{label}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/human_eval.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/human_eval.yaml
@@ -1,0 +1,144 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: human_eval_claude
+description: Claude eval on HumanEval
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 500, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: openai_humaneval
+      split: test
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a function definition with comments inside it describing what the function must do. \
+      You are asked to fill in the function body with code that satisfies the comments. Your function must pass the test \
+      functions given in the input. Output must be code only with no explanations. \
+      Output must be only code beginning with [BEGIN] and ending with [DONE] tags. \
+      Make sure to include the function definition statement and the function body.\n\nHuman:\n"
+      prompt_pattern: "{{prompt}}\n\nAssistant:\n\n"
+      n_shots: 0
+      output_pattern: |-
+        {{test}}
+        check({{entry_point}})
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 1
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: '\[BEGIN\](.*?)\[DONE\]'
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: text-generation
+      ground_truth_column_name: ',completion'
+      prediction_column_name: prediction
+      evaluation_config_params: '{"sub_task": "code"}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_humanities.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_humanities.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_humanities_claude
+description: Claude eval on MMLU Humanities
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: formal_logic,high_school_european_history,high_school_us_history,high_school_world_history,international_law,jurisprudence,logical_fallacies,moral_disputes,moral_scenarios,philosophy,prehistory,professional_law,world_religions
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: formal_logic,high_school_european_history,high_school_us_history,high_school_world_history,international_law,jurisprudence,logical_fallacies,moral_disputes,moral_scenarios,philosophy,prehistory,professional_law,world_religions
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to choose between options A, B, C, or D. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only the letter of the option you choose. This letter must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\n### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      ### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer: {{answer}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{answer}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_other.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_other.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_other_claude
+description: Claude eval on MMLU Other
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: business_ethics,clinical_knowledge,college_medicine,global_facts,human_aging,management,marketing,medical_genetics,miscellaneous,nutrition,professional_accounting,professional_medicine,virology
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: business_ethics,clinical_knowledge,college_medicine,global_facts,human_aging,management,marketing,medical_genetics,miscellaneous,nutrition,professional_accounting,professional_medicine,virology
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to choose between options A, B, C, or D. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only the letter of the option you choose. This letter must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\n### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      ### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer: {{answer}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{answer}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_social_sciences.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_social_sciences.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_social_sciences_claude
+description: Claude eval on MMLU Social Sciences
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: econometrics,high_school_geography,high_school_government_and_politics,high_school_macroeconomics,high_school_microeconomics,high_school_psychology,human_sexuality,professional_psychology,public_relations,security_studies,sociology,us_foreign_policy
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: econometrics,high_school_geography,high_school_government_and_politics,high_school_macroeconomics,high_school_microeconomics,high_school_psychology,human_sexuality,professional_psychology,public_relations,security_studies,sociology,us_foreign_policy
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to choose between options A, B, C, or D. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only the letter of the option you choose. This letter must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\n### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      ### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer: {{answer}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{answer}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_stem.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/mmlu_stem.yaml
@@ -1,0 +1,224 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: mmlu_stem_claude
+description: Claude eval on MMLU STEM
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: abstract_algebra,anatomy,astronomy,college_biology,college_chemistry,college_computer_science,college_mathematics,college_physics,computer_security,conceptual_physics,electrical_engineering,elementary_mathematics,high_school_biology,high_school_chemistry,high_school_computer_science,high_school_mathematics,high_school_physics,high_school_statistics,machine_learning
+      split: test
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      configuration: abstract_algebra,anatomy,astronomy,college_biology,college_chemistry,college_computer_science,college_mathematics,college_physics,computer_security,conceptual_physics,electrical_engineering,elementary_mathematics,high_school_biology,high_school_chemistry,high_school_computer_science,high_school_mathematics,high_school_physics,high_school_statistics,machine_learning
+      split: dev
+      script_path:
+        type: uri_file
+        path: https://raw.githubusercontent.com/Azure/azureml-assets/main/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question}}, "choices":{{choices}}, "answer":{{answer|string}}}'
+      encoder_config: '{"column_name": "answer", "0": "A", "1": "B", "2": "C", "3":
+        "D"}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to choose between options A, B, C, or D. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only the letter of the option you choose. This letter must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\n### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      ### Question: {{question}}\n\
+      A. {{choices[0]}}\n\
+      B. {{choices[1]}}\n\
+      C. {{choices[2]}}\n\
+      D. {{choices[3]}}\n\
+      ###Answer: {{answer}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{answer}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/openbookqa.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/openbookqa.yaml
@@ -1,0 +1,222 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: openbookqa_claude
+description: Claude eval on OpenBookQA
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: openbookqa
+      configuration: main
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question_stem}}, "choices":{{choices.text}},
+        "answer":{{answerKey}}}'
+      encoder_config: '{"column_name": "answer", "A": 1, "B": 2, "C": 3, "D": 4}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: openbookqa
+      configuration: main
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: '{"question":{{question_stem}}, "choices":{{choices.text}},
+        "answer":{{answerKey}}}'
+      encoder_config: '{"column_name": "answer", "A": 1, "B": 2, "C": 3, "D": 4}'
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to choose between answers in options 1, 2, 3, or 4. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only the number of the option you choose. This number must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\nQuestion: {{question}}\n\
+      Answer options:\n\
+      (1) {{choices[0]}}\n\
+      (2) {{choices[1]}}\n\
+      (3) {{choices[2]}}\n\
+      (4) {{choices[3]}}\n\
+      The answer is:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      Question: {{question}}\n\
+      Answer options:\n\
+      (1) {{choices[0]}}\n\
+      (2) {{choices[1]}}\n\
+      (3) {{choices[2]}}\n\
+      (4) {{choices[3]}}\n\
+      The answer is: {{answer}}\n\
+      </example>"
+      n_shots: 10
+      output_pattern: '{{answer}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 3
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/piqa.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/piqa.yaml
@@ -1,0 +1,184 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: piqa_claude
+description: Claude eval on PIQA
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: piqa
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: piqa
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 0.3
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a problem and asked to choose between answers in options 1 or 2. \
+        There are examples within <example> tags for you to learn from. For the last question respond \
+        with only the number of the option you choose. This number must be within the tags \
+        <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\nGoal: {{goal}}\n\
+      Answer options:\n\
+      (1) {{sol1}}\n\
+      (2) {{sol2}}\n\
+      The answer is:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      Goal: {{goal}}\n\
+      Answer options:\n\
+      (1) {{sol1}}\n\
+      (2) {{sol2}}\n\
+      The answer is: {{ (label + 1) }}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{ (label + 1) }}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/social_iqa.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/social_iqa.yaml
@@ -1,0 +1,220 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: social_iqa_claude
+description: Claude eval on Social IQA
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: social_i_qa
+      configuration: all
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": {{answerA}},\n\
+        \  \"answerB\": {{answerB}},\n  \"answerC\": {{answerC}},\n  \"context\":\
+        \ {{context}},\n  \"target\": {{label}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: social_i_qa
+      configuration: all
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: random
+      sampling_ratio: 0.3
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_preprocessor:
+    type: command
+    component: azureml://registries/azureml/components/dataset_preprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      template_input: "{\n  \"question\": {{question}},\n  \"answerA\": {{answerA}},\n\
+        \  \"answerB\": {{answerB}},\n  \"answerC\": {{answerC}},\n  \"context\":\
+        \ {{context}},\n  \"target\": {{label}}\n}"
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.preprocessor.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_preprocessor.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a question along with context and asked to choose between answers in options 1, 2 or 3. \
+      There are examples within <example> tags for you to learn from. For the last question respond with only the number \
+      of the option you choose. This number must be within the tags <answer> and </answer>. \
+      Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\nGiven the context answer the question: context: {{context}}\n\
+      question: {{question}}\n\
+      1.: {{answerA}}\n\
+      2.: {{answerB}}\n\
+      3.: {{answerC}}\n\
+      Answer:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      Given the context answer the question: context: {{context}}\n\
+      question: {{question}}\n\
+      1.: {{answerA}}\n\
+      2.: {{answerB}}\n\
+      3.: {{answerC}}\n\
+      Answer: {{target}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{target}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      evaluation_config_params: '{"regexes_to_ignore": ["\\W"]}'
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless

--- a/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/winogrande.yaml
+++ b/sdk/python/foundation-models/benchmarking/evaluation_pipelines/claude-2_1/winogrande.yaml
@@ -1,0 +1,189 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+type: pipeline
+display_name: winogrande_claude
+description: Claude eval on Winogrande
+inputs:
+  endpoint_url: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2:1/invoke
+  ws_connection_name: <connection name>
+  payload_pattern: '{"prompt": "###<prompt>", "temperature": 0.0, "max_tokens_to_sample": 10, "top_p": 1.0}'
+  sample_ratio: 1.0
+jobs:
+  downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: winogrande
+      configuration: winogrande_xs
+      split: validation
+    outputs:
+      output_dataset:
+        type: uri_folder
+  sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: ${{parent.inputs.sample_ratio}}
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  fewshot_downloader:
+    type: command
+    component: azureml://registries/azureml/components/dataset_downloader/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset_name: winogrande
+      configuration: winogrande_xs
+      split: train
+    outputs:
+      output_dataset:
+        type: uri_folder
+  fewshot_sampler:
+    type: command
+    component: azureml://registries/azureml/components/dataset_sampler/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      dataset:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_downloader.outputs.output_dataset}}
+      sampling_style: head
+      sampling_ratio: 1.0
+      random_seed: 0
+    outputs:
+      output_dataset:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  promptcrafter:
+    type: command
+    component: azureml://registries/azureml/components/prompt_crafter/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      test_data:
+        type: uri_folder
+        path: ${{parent.jobs.sampler.outputs.output_dataset}}
+      few_shot_data:
+        type: uri_folder
+        path: ${{parent.jobs.fewshot_sampler.outputs.output_dataset}}
+      prompt_type: completions
+      prefix: "\n\nYou are given a text with a blank and asked to choose between answers in options 1 or 2 to fill in the blank. \
+      There are examples within <example> tags for you to learn from. For the last question respond with only the number of the option you choose. \
+      This number must be within the tags <answer> and </answer>. Do not add other text to the response.\n\nHuman:"
+      prompt_pattern: "\n### Text:\n\n\
+      {{sentence}}\n\n\
+      ### Option 1:\n\n\
+      {{option1}}\n\n\
+      ### Option 2:\n\n\
+      {{option2}}\n\n\
+      ### Answer:\n\nAssistant:\n\n"
+      few_shot_pattern: "<example>\n\
+      ### Text:\n\n\
+      {{sentence}}\n\n\
+      ### Option 1:\n\n\
+      {{option1}}\n\n\
+      ### Option 2:\n\n\
+      {{option2}}\n\n\
+      ### Answer:{{answer}}\n\
+      </example>"
+      n_shots: 5
+      output_pattern: '{{answer}}'
+      few_shot_separator: "\n\n"
+      random_seed: 0
+    outputs:
+      output_file:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  endpoint:
+    type: pipeline
+    component: azureml://registries/azureml/components/batch_benchmark_inference_claude/labels/latest
+    inputs:
+      input_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.promptcrafter.outputs.output_file}}
+      batch_input_pattern: ${{parent.inputs.payload_pattern}}
+      endpoint_url: ${{parent.inputs.endpoint_url}}
+      is_performance_test: false
+      connections_name: ${{parent.inputs.ws_connection_name}}
+      label_column_name: completion
+      handle_response_failure: use_fallback
+      ensure_ascii: false
+      initial_worker_count: 1
+      max_worker_count: 10
+      instance_count: 1
+      max_concurrency_per_instance: 1
+      debug_mode: false
+    outputs:
+      predictions:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      performance_metadata:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+      ground_truth:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  postprocessor:
+    type: command
+    component: azureml://registries/azureml/components/inference_postprocessor/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.ground_truth}}
+      prediction_dataset:
+        type: uri_folder
+        path: ${{parent.jobs.endpoint.outputs.predictions}}
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+      separator: "###" 
+      regex_expr: "<answer>(.*?)</answer>"
+    outputs:
+      output_dataset_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.jsonl
+  quality:
+    type: command
+    component: azureml://registries/azureml/components/compute_metrics/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      ground_truth:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      prediction:
+        type: uri_folder
+        path: ${{parent.jobs.postprocessor.outputs.output_dataset_result}}
+      task: question-answering
+      ground_truth_column_name: completion
+      prediction_column_name: prediction
+    outputs:
+      evaluation_result:
+        type: uri_folder
+  aggregator:
+    type: command
+    component: azureml://registries/azureml/components/benchmark_result_aggregator/labels/latest
+    limits:
+      timeout: 900
+    inputs:
+      quality_metrics:
+        type: uri_folder
+        path: ${{parent.jobs.quality.outputs.evaluation_result}}
+    outputs:
+      benchmark_result:
+        type: uri_file
+        path: azureml://datastores/${{default_datastore}}/paths/azureml/${{name}}/${{output_name}}.json
+settings:
+  force_rerun: false
+  default_compute: azureml:serverless


### PR DESCRIPTION
# Description
Added two new notebooks for Claude and OpenAI model evaluation, each with 12 pipeline definitions for launching benchmark runs in AzureML.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
