### PR TITLE
increase RAI dbpedia notebook timeout to 3 hours from 2 hours to reduce transient failures

### DIFF
--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-DBPedia.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-DBPedia.ipynb
@@ -839,7 +839,7 @@
     "        classes=classes,\n",
     "        use_model_dependency=use_model_dependency,\n",
     "    )\n",
-    "    rai_text_job.set_limits(timeout=7200)\n",
+    "    rai_text_job.set_limits(timeout=10800)\n",
     "\n",
     "    rai_text_job.outputs.dashboard.mode = \"upload\"\n",
     "    rai_text_job.outputs.ux_json.mode = \"upload\"\n",


### PR DESCRIPTION
# Description

increase RAI dbpedia notebook timeout to 3 hours from 2 hours to reduce transient failures

Seeing some notebook test failures like here:
https://ml.azure.com/experiments/id/d09c857d-f878-4036-ba2a-033dd75c37ef/runs/placid_glass_dmydn8v1v3?wsid=/subscriptions/b17253fa-f327-42d6-9686-f3e553e24763/resourcegroups/amlsdkv2022401/providers/Microsoft.MachineLearningServices/workspaces/amlsdkv2022401-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
With timeout errors:
![image](https://github.com/Azure/azureml-examples/assets/24683184/a5d2293e-a1f7-4cba-a480-d361d487c5a5)
Usually the notebook takes about 1.2 hours to run with high variance.  In cases the component run takes 2 hours the test fails.
![image](https://github.com/Azure/azureml-examples/assets/24683184/2558d477-033f-4369-abfd-7d97e7c6b70f)
Increasing the timeout to resolve these transient failures.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
