### PR TITLE
Update batch endpoint cli and sdk notebook examples to use newer images

### DIFF
--- a/cli/endpoints/batch/deploy-models/imagenet-classifier/deployment-by-batch.yml
+++ b/cli/endpoints/batch/deploy-models/imagenet-classifier/deployment-by-batch.yml
@@ -6,8 +6,8 @@ type: model
 model: azureml:imagenet-classifier@latest
 compute: azureml:gpu-cluster
 environment:
-  name: tensorflow27-cuda11-gpu
-  image: mcr.microsoft.com/azureml/curated/tensorflow-2.7-ubuntu20.04-py38-cuda11-gpu:latest
+  name: tensorflow212-cuda11-gpu
+  image: mcr.microsoft.com/azureml/curated/tensorflow-2.12-cuda11:latest
   conda_file: environment/conda.yaml
 code_configuration:
   code: code/score-by-batch

--- a/cli/endpoints/batch/deploy-models/imagenet-classifier/deployment-by-file.yml
+++ b/cli/endpoints/batch/deploy-models/imagenet-classifier/deployment-by-file.yml
@@ -6,8 +6,8 @@ type: model
 model: azureml:imagenet-classifier@latest
 compute: azureml:gpu-cluster
 environment:
-  name: tensorflow27-cuda11-gpu
-  image: mcr.microsoft.com/azureml/curated/tensorflow-2.7-ubuntu20.04-py38-cuda11-gpu:latest
+  name: tensorflow212-cuda11-gpu
+  image: mcr.microsoft.com/azureml/curated/tensorflow-2.12-cuda11:latest
   conda_file: environment/conda.yaml
 code_configuration:
   code: code/score-by-file

--- a/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
@@ -691,9 +691,9 @@
    "outputs": [],
    "source": [
     "environment = Environment(\n",
-    "    name=\"tensorflow27-cuda11-gpu\",\n",
+    "    name=\"tensorflow212-cuda11-gpu\",\n",
     "    conda_file=\"environment/conda.yaml\",\n",
-    "    image=\"mcr.microsoft.com/azureml/curated/tensorflow-2.7-ubuntu20.04-py38-cuda11-gpu:latest\",\n",
+    "    image=\"mcr.microsoft.com/azureml/curated/tensorflow-2.12-cuda11:latest\",\n",
     ")"
    ]
   },


### PR DESCRIPTION
# Description

The previous image used in batch endpoint examples is out of its EOL date and deprecated. Replace them by the newer image to recover the tests.
 
# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
