### PR TITLE
ci: Fix 'file does not exist' when running check-readme

### DIFF
--- a/infra/bootstrapping/check-readme.py
+++ b/infra/bootstrapping/check-readme.py
@@ -11,7 +11,7 @@ argParser.add_argument(
 )
 args = argParser.parse_args()
 sample_path = str(args.sample_path).strip()
-working_directory = Path(__file__).parent.parent
+working_directory = Path(__file__).resolve().parent.parent
 
 
 def main():

--- a/infra/bootstrapping/check-readme.py
+++ b/infra/bootstrapping/check-readme.py
@@ -11,14 +11,12 @@ argParser.add_argument(
 )
 args = argParser.parse_args()
 sample_path = str(args.sample_path).strip()
-working_directory = Path(__file__).resolve().parent.parent
+repo_root = Path(__file__).resolve().parent.parent
 
 
 def main():
     INVALID_README_MSG = f"{sample_path} does not contain a README.md file with all required words. See the Discoverability section of CONTRIBUTING.md."
-    EXCLUSIONS_FILE_PATH = (
-        f"{working_directory}/bootstrapping/readme_validation_exclusions.txt"
-    )
+    EXCLUSIONS_FILE_PATH = f"{repo_root}/bootstrapping/readme_validation_exclusions.txt"
     required_sections = [
         "overview",
         "objective",


### PR DESCRIPTION
# Description

This pull request fixes a bug in CI where the check-readme.py step is unable to find the exclusion list.

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
