### PR TITLE
forecast-tcn notebook fix by using less nodes

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-distributed-tcn/automl-forecasting-distributed-tcn.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-distributed-tcn/automl-forecasting-distributed-tcn.ipynb
@@ -427,7 +427,7 @@
     "timeout_minutes = 60\n",
     "max_concurrent_trials = 5\n",
     "max_trials = 15\n",
-    "max_nodes = 10\n",
+    "max_nodes = 8\n",
     "enable_early_termination = True"
    ]
   },


### PR DESCRIPTION
# Description
The notebook is broken because the cluster allocates 10 nodes, starts the setup run with 1 of the nodes, and then while the setup run is still running, a child run tries to launch with 10 nodes. This causes the child run to be queued waiting for all 10 nodes to become available, which never happens and the job just hangs until it times out. This PR fixes that by reducing the number of nodes used by the child run.
Fixed run: https://github.com/Azure/azureml-examples/actions/runs/7908820835
# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
