### PR TITLE
Updated test_json of  text-generation-online-endpoint-dolly.ipynb 

### DIFF
--- a/sdk/python/foundation-models/system/inference/text-generation/text-generation-online-endpoint-dolly.ipynb
+++ b/sdk/python/foundation-models/system/inference/text-generation/text-generation-online-endpoint-dolly.ipynb
@@ -223,7 +223,7 @@
     "# create a json object with the key as \"inputs\" and value as a list of values from the article column of the sample_df dataframe\n",
     "sample_json = {\"inputs\": sample_df[\"text\"].tolist()}\n",
     "# save the json object to a file named sample_score_dolly.json in the ./book-corpus-dataset folder\n",
-    "test_json = {\"input_data\": {\"input_string\": sample_df[\"text\"].tolist()}}\n",
+    "test_json = {\"input_data\": {\"input_string\": [sample_df[\"text\"].tolist()[0]]}}\n",
     "# save the json object to a file named sample_score_dolly.json in the ./book-corpus-dataset folder\n",
     "with open(\n",
     "    os.path.join(\".\", \"book-corpus-dataset\", \"sample_score_dolly.json\"), \"w\"\n",


### PR DESCRIPTION
Updated test_json of  text-generation-online-endpoint-dolly.ipynb to avoid the "unexpected error " while invoking sample json

Changing test_json as it throws Unexpected error while invoking. on the endpoint logs it shows "Expecting a list got a dictionary instead" so changed to list eventually after testing my side on Azure notebook.  You can verify the syntax endpoint expect on the consume tab of online endpoint.

Feel free to change sample_json also if needed

# Description
Customers are getting unexpected error as endpoint is expecting a list and test_json in dictionary format
Verified with sample data in consume tab and modified python notebook accordingly

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
