### PR TITLE
Remove recordclass from the conda dependencies

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
@@ -843,10 +843,10 @@
     "with open(conda_file_name, \"r\") as f:\n",
     "    conda_file_lines = f.readlines()\n",
     "\n",
-    "conda_file_lines.remove(\"- recordclass=0.15.1\\n\")\n",
-    "\n",
     "with open(conda_file_name, \"w\") as f:\n",
-    "    f.writelines(conda_file_lines)"
+    "    for line in conda_file_lines:\n",
+    "        if not \"recordclass\" in line:\n",
+    "            f.write(line)"
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
@@ -831,6 +831,25 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# recordclass=0.15.1 is not available in conda\n",
+    "\n",
+    "conda_file_name = \"artifact_downloads/outputs/conda_env_v_1_0_0.yml\"\n",
+    "\n",
+    "with open(conda_file_name, \"r\") as f:\n",
+    "    conda_file_lines = f.readlines()\n",
+    "\n",
+    "conda_file_lines.remove(\"- recordclass=0.15.1\\n\")\n",
+    "\n",
+    "with open(conda_file_name, \"w\") as f:\n",
+    "    f.writelines(conda_file_lines)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -853,9 +872,7 @@
     "    description=\"environment for automl images inference\",\n",
     "    image=\"mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.6-cudnn8-ubuntu20.04\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
-    ")\n",
-    "\n",
-    "env.conda_file[\"dependencies\"].remove(\"recordclass=0.15.1\")"
+    ")"
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
@@ -835,7 +835,7 @@
    "metadata": {},
    "source": [
     "## 6.2 Configure environment\n",
-    "It is recommended to use the same envionment for model deployment as the model training, therefore we are creating the Environment object using the conda environment file downloaded as artifacts. We also need to specify the base image, which in case of vision tasks, is `mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.1-cudnn8-ubuntu18.04`\n",
+    "It is recommended to use the same envionment for model deployment as the model training, therefore we are creating the Environment object using the conda environment file downloaded as artifacts. We also need to specify the base image, which in case of vision tasks, is `mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.6-cudnn8-ubuntu20.04`\n",
     "\n",
     "To read more about environments, please follow this [notebook](./../../../assets/environment/environment.ipynb)"
    ]
@@ -853,7 +853,9 @@
     "    description=\"environment for automl images inference\",\n",
     "    image=\"mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.6-cudnn8-ubuntu20.04\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
-    ")"
+    ")\n",
+    "\n",
+    "env.conda_file[\"dependencies\"].remove(\"recordclass=0.15.1\")"
    ]
   },
   {


### PR DESCRIPTION
# Description
Remove "recordclass=0.15.1", which is not available in conda.
Also, fixed documentation for base image.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
