### PR TITLE
Fix github-dau notebook with out of date environment

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -714,7 +714,7 @@
     "env = Environment(\n",
     "    name=\"automl-tabular-env-tcn\",\n",
     "    description=\"environment for automl TCN inference\",\n",
-    "    image=\"mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.1-cudnn8-ubuntu20.04:latest\",\n",
+    "    image=\"mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
     ")\n",
     "\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -714,7 +714,7 @@
     "env = Environment(\n",
     "    name=\"automl-tabular-env-tcn\",\n",
     "    description=\"environment for automl TCN inference\",\n",
-    "    image=\"mcr.microsoft.com/azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference:latest\",\n",
+    "    image=\"mcr.microsoft.com/azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference:32\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
     ")\n",
     "\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -714,7 +714,7 @@
     "env = Environment(\n",
     "    name=\"automl-tabular-env-tcn\",\n",
     "    description=\"environment for automl TCN inference\",\n",
-    "    image=\"mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest\",\n",
+    "    image=\"mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.1-cudnn8-ubuntu20.04:latest\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
     ")\n",
     "\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -714,7 +714,7 @@
     "env = Environment(\n",
     "    name=\"automl-tabular-env-tcn\",\n",
     "    description=\"environment for automl TCN inference\",\n",
-    "    image=\"mcr.microsoft.com/azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference:28\",\n",
+    "    image=\"mcr.microsoft.com/azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
     ")\n",
     "\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -714,7 +714,7 @@
     "env = Environment(\n",
     "    name=\"automl-tabular-env-tcn\",\n",
     "    description=\"environment for automl TCN inference\",\n",
-    "    image=\"mcr.microsoft.com/azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference:32\",\n",
+    "    image=\"mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
     ")\n",
     "\n",

--- a/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
@@ -714,7 +714,7 @@
     "env = Environment(\n",
     "    name=\"automl-tabular-env-tcn\",\n",
     "    description=\"environment for automl TCN inference\",\n",
-    "    image=\"mcr.microsoft.com/azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference\",\n",
+    "    image=\"mcr.microsoft.com/azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference:latest\",\n",
     "    conda_file=\"artifact_downloads/outputs/conda_env_v_1_0_0.yml\",\n",
     ")\n",
     "\n",


### PR DESCRIPTION
# Description
This notebook is failing with:

Specified image azureml/curated/minimal-ubuntu20.04-py38-cuda11.6.2-gpu-inference @ sha256:8ac695c30f4b8ddddb7383430e1e981de6e48ad1575a969d5d65eaab9b80441b reached EOL 04/09/2024 00:00:00..

This PR fixes the notebook to use an updated environment.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
