### PR TITLE
Update webrequests.ipynb

### DIFF
--- a/sdk/python/foundation-models/mistral/webrequests.ipynb
+++ b/sdk/python/foundation-models/mistral/webrequests.ipynb
@@ -144,7 +144,6 @@
     "    ],\n",
     "    \"max_tokens\": 500,\n",
     "    \"temperature\": 0.9,\n",
-    "    \"stream\": \"True\",\n",
     "}\n",
     "\n",
     "body = str.encode(json.dumps(data))\n",


### PR DESCRIPTION
Remove “HTTP Requests API Usage in Python” cell, "stream: true" parameter in "data" JSON. Looks like API not support this here.

# Description
Use this parameter will trige issue, "400: Unsupport data type" like below:

The request failed with status code: 400
Content-Length: 22
Content-Type: text/plain; charset=utf-8
x-content-type-options: nosniff
x-ms-rai-invoked: true
x-request-id: *****
ms-azureml-model-error-reason: model_error
ms-azureml-model-error-statuscode: 400
x-ms-client-request-id: *****
Request-Context: appId=cid-v1:*****
azureml-model-session: dep-mistral-sdc-mistrallarge-0
azureml-model-group: mistral-large-scaleset-sdc
Date: Sun, 14 Apr 2024 15:56:21 GMT
Connection: close


Unsupported data type

# Checklist


- [X] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [X] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
