### PR TITLE
Update langchain.ipynb on Mistral call

### DIFF
--- a/sdk/python/foundation-models/mistral/langchain.ipynb
+++ b/sdk/python/foundation-models/mistral/langchain.ipynb
@@ -103,7 +103,7 @@
    "source": [
     "Let's create an instance of our Mistral model deployed in Azure AI or Azure ML. Use `langchain_mistralai` package and configure it as follows:\n",
     "\n",
-    "- `endpoint`: Use the endpoint URL from your deployment. Do not include either `v1/chat/completions` as this is included automatically by the client.\n",
+    "- `endpoint`: Use the endpoint URL from your deployment. Do not include either `chat/completions` as this is included automatically by the client.\n",
     "- `api_key`: Use your API key."
    ]
   },
@@ -116,7 +116,7 @@
    "outputs": [],
    "source": [
     "chat_model = ChatMistralAI(\n",
-    "    endpoint=\"https://<endpoint>.<region>.inference.ai.azure.com\",\n",
+    "    endpoint=\"https://<endpoint>.<region>.inference.ai.azure.com/v1\",\n",
     "    mistral_api_key=\"<key>\",\n",
     ")"
    ]


### PR DESCRIPTION
Similar to Cohere, '/v1' was missing on the endpoint! It took me a couple hours but then spotted this on the Cohere notebook.

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
