### PR TITLE
update RAI image version to latest for mlflow-deployment-with-explanations example notebook

### DIFF
--- a/sdk/python/responsible-ai/mlflow-deployment-with-explanations/env.yml
+++ b/sdk/python/responsible-ai/mlflow-deployment-with-explanations/env.yml
@@ -4,7 +4,8 @@ dependencies:
   - python=3.9.13
   - pip<=21.2.4
   - pip:
-      - responsibleai==0.29.0
+      - responsibleai==0.34.1
+      - scikit-learn~=1.3.2
       - ml-wrappers
       - mlflow
       - raiutils

--- a/sdk/python/responsible-ai/mlflow-deployment-with-explanations/mlflow-deployment-with-explanations.ipynb
+++ b/sdk/python/responsible-ai/mlflow-deployment-with-explanations/mlflow-deployment-with-explanations.ipynb
@@ -87,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diabetes_regression_example_version_string = \"1\""
+    "diabetes_regression_example_version_string = \"7\""
    ]
   },
   {
@@ -535,7 +535,7 @@
     "  model_output:\n",
     "    type: path\n",
     "code: ./component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/21\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/49\n",
     "\"\"\"\n",
     "    + r\"\"\"\n",
     "command: >-\n",
@@ -580,7 +580,7 @@
     "  model_info_output_path:\n",
     "    type: path\n",
     "code: ./register_model_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/21\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/49\n",
     "command: >-\n",
     "  python register.py\n",
     "  --model_input_path ${{{{inputs.model_input_path}}}}\n",
@@ -799,9 +799,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wrapper_model_name = (\n",
-    "    \"diabetes_model_with_explanations\"  # Name for the model with explanations\n",
-    ")"
+    "# Name for the model with explanations\n",
+    "wrapper_model_name = f\"diabetes_model_with_explanations_{model_name_suffix}\""
    ]
   },
   {
@@ -838,7 +837,9 @@
     "import mltable\n",
     "\n",
     "\n",
-    "data_asset = ml_client.data.get(name=input_train_data, version=1)\n",
+    "data_asset = ml_client.data.get(\n",
+    "    name=input_train_data, version=diabetes_regression_example_version_string\n",
+    ")\n",
     "baseline_df = mltable.load(train_data_path).to_pandas_dataframe()\n",
     "# Drop any columns that were dropped when training the model. Uncomment and fill in first parameter\n",
     "# baseline_df = baseline_df.drop([], axis=\"columns\")\n",

--- a/sdk/python/responsible-ai/mlflow-deployment-with-explanations/requirements.txt
+++ b/sdk/python/responsible-ai/mlflow-deployment-with-explanations/requirements.txt
@@ -7,4 +7,6 @@ mltable
 ml-wrappers
 plotly
 nbformat
-responsibleai==0.29.0
+responsibleai==0.34.1
+# make sure this matches the version in the RAI tabular image
+scikit-learn~=1.3.2


### PR DESCRIPTION
# Description

Update RAI image version to latest for mlflow-deployment-with-explanations example notebook.

Seeing notebook failures in internal tests during sdk upgrade:
"image reached EOL"
Please see related PR for more details, which fixed similar notebooks:
https://github.com/Azure/azureml-examples/pull/3145


# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
