### PR TITLE
Fix program name in Python pipeline `1a_pipeline_with_components_from…

### DIFF
--- a/sdk/python/jobs/pipelines/1a_pipeline_with_components_from_yaml/eval_src/eval.py
+++ b/sdk/python/jobs/pipelines/1a_pipeline_with_components_from_yaml/eval_src/eval.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 from datetime import datetime
 
-parser = argparse.ArgumentParser("score")
+parser = argparse.ArgumentParser("eval")
 parser.add_argument("--scoring_result", type=str, help="Path of scoring result")
 parser.add_argument("--eval_output", type=str, help="Path of output evaluation result")
 


### PR DESCRIPTION
# Description

Just a wording issue

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
