### PR TITLE
checking for computes in 'finetune_compute_allow_list' instead of compute_allow_list

### DIFF
--- a/sdk/python/foundation-models/system/finetune/chat-completion/chat-completion.ipynb
+++ b/sdk/python/foundation-models/system/finetune/chat-completion/chat-completion.ipynb
@@ -148,14 +148,14 @@
    "source": [
     "import ast\n",
     "\n",
-    "if \"computes_allow_list\" in foundation_model.tags:\n",
+    "if \"finetune_compute_allow_list\" in foundation_model.tags:\n",
     "    computes_allow_list = ast.literal_eval(\n",
-    "        foundation_model.tags[\"computes_allow_list\"]\n",
+    "        foundation_model.tags[\"finetune_compute_allow_list\"]\n",
     "    )  # convert string to python list\n",
     "    print(f\"Please create a compute from the above list - {computes_allow_list}\")\n",
     "else:\n",
     "    computes_allow_list = None\n",
-    "    print(\"Computes allow list is not part of model tags\")"
+    "    print(\"`finetune_compute_allow_list` is not part of model tags\")"
    ]
   },
   {


### PR DESCRIPTION
# Description
Validating the compute before submitting the job helps to fail the run before even submitting the job. In order to do that the finetuning notebooks depend on `finetune_compute_allow_list` flag. This flag name is new and earlier used to be `compute_allow_list`. This PR fixes this change in chat_completion_pipeline notebook.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
