### PR TITLE
bump RAI text and vision component versions to 0.0.16

### DIFF
--- a/sdk/python/responsible-ai/text/responsibleaidashboard-multilabel-text-classification-covid-events.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-multilabel-text-classification-covid-events.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"17\""
+    "rai_example_version_string = \"18\""
    ]
   },
   {
@@ -595,7 +595,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./covid19_events_component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/49\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/51\n",
     "command: >-\n",
     "  python training_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",
@@ -669,7 +669,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"multilabel_hf_model\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-DBPedia.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-DBPedia.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"17\""
+    "rai_example_version_string = \"18\""
    ]
   },
   {
@@ -576,7 +576,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./dbpedia_component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/49\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/51\n",
     "command: >-\n",
     "  python training_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",
@@ -650,7 +650,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"hf_model\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"29\""
+    "rai_example_version_string = \"30\""
    ]
   },
   {
@@ -568,7 +568,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./blbooksgenre_component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/49\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/51\n",
     "command: >-\n",
     "  python training_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",

--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-financial-news/responsibleaidashboard-text-classification-financial-news.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-financial-news/responsibleaidashboard-text-classification-financial-news.ipynb
@@ -133,7 +133,7 @@
    },
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -194,7 +194,7 @@
    },
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"15\""
+    "rai_example_version_string = \"16\""
    ]
   },
   {
@@ -1076,7 +1076,7 @@
     "  model_info_output_path:\n",
     "    type: path\n",
     "code: ./Text_classification_component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/49\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/51\n",
     "\"\"\"\n",
     "    + r\"\"\"\n",
     "command: >-\n",
@@ -1184,7 +1184,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"Financial_News_classifier\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-question-answering-squad.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-question-answering-squad.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"8\""
+    "rai_example_version_string = \"9\""
    ]
   },
   {
@@ -503,7 +503,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./squad_component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/49\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/51\n",
     "command: >-\n",
     "  python training_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",
@@ -576,7 +576,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"hf_qa_model\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-automl-image-classification-fridge.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-automl-image-classification-fridge.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"57\""
+    "rai_example_version_string = \"58\""
    ]
   },
   {

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-automl-object-detection-fridge-private-data.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-automl-object-detection-fridge-private-data.ipynb
@@ -99,7 +99,7 @@
    },
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-image-classification-fridge.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-image-classification-fridge.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"15\""
+    "rai_example_version_string = \"16\""
    ]
   },
   {
@@ -505,7 +505,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./fridge_component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/54\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/56\n",
     "command: >-\n",
     "  python training_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",
@@ -579,7 +579,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"fridge_model\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-image-flower-classification.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-image-flower-classification.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"7\""
+    "rai_example_version_string = \"8\""
    ]
   },
   {
@@ -830,7 +830,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/54\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/56\n",
     "command: >-\n",
     "  python training_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",
@@ -912,7 +912,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"flower_classification_model\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-image-multilabel-classification-fridge.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-image-multilabel-classification-fridge.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\""
+    "version_string = \"0.0.16\""
    ]
   },
   {
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"16\""
+    "rai_example_version_string = \"17\""
    ]
   },
   {
@@ -509,7 +509,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./fridge_component_src/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/54\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/56\n",
     "command: >-\n",
     "  python training_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",
@@ -583,7 +583,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"multilabel_fridge_model\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-object-detection-MSCOCO.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-object-detection-MSCOCO.ipynb
@@ -18,9 +18,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "version_string = \"0.0.15\"\n",
+    "version_string = \"0.0.16\"\n",
     "compute_name = \"cpucluster\"\n",
-    "rai_example_version_string = \"15\""
+    "rai_example_version_string = \"16\""
    ]
   },
   {
@@ -397,7 +397,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"mscoco_model\"\n",
-    "model_name_suffix = \"12488\"\n",
+    "model_name_suffix = \"12489\"\n",
     "device = -1"
    ]
   },
@@ -436,7 +436,7 @@
     "  model_output_path:\n",
     "    type: path\n",
     "code: ./mscoco_component_src_od_1/\n",
-    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/54\n",
+    "environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/56\n",
     "command: >-\n",
     "  python model_script.py\n",
     "  --model_base_name ${{{{inputs.model_base_name}}}}\n",


### PR DESCRIPTION
# Description

bump RAI text and vision component versions to 0.0.16 in azureml-examples repository for all text and vision notebooks

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
