### PR TITLE
Removing the pipeline validation which fails due to missing path

### DIFF
--- a/sdk/python/foundation-models/system/finetune/chat-completion/chat-completion.ipynb
+++ b/sdk/python/foundation-models/system/finetune/chat-completion/chat-completion.ipynb
@@ -450,27 +450,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Validate the pipeline against data and compute"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# comment this section to disable validation\n",
-    "# Makesure to turn off the validation if your data is too big. Alternatively, validate the run with small data before launching runs with large datasets\n",
-    "\n",
-    "%run ../../pipeline_validations/common.ipynb\n",
-    "\n",
-    "validate_pipeline(pipeline_object, workspace_ml_client)"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
# Description
Removing the pipeline validation section which fails today for 2 reasons
1. Import for pipeline validation fail
![image](https://github.com/Azure/azureml-examples/assets/12165281/0b931021-3d92-49eb-8ae6-400c174b799d)
2. Validation is not handled when any of the train/validation/test file paths are missing.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
