### PR TITLE
Update train.yml to enable example pipelines

### DIFF
--- a/cli/assets/component/train.yml
+++ b/cli/assets/component/train.yml
@@ -4,7 +4,7 @@ display_name: train_data
 description: A example train component
 tags:
   author: azureml-sdk-team
-version: 9
+version: 10
 type: command
 inputs:
   training_data: 


### PR DESCRIPTION
# Description

Update train.yml to enable example pipelines

Original Error
![image](https://github.com/Azure/azureml-examples/assets/2208599/3a3b52b1-8aa1-425e-a158-79940e22d69d)

Version 9 is refusing update.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
