### PR TITLE
Replace timeout by wait() in registry creation.

### DIFF
--- a/sdk/python/resources/registry/registry-create.ipynb
+++ b/sdk/python/resources/registry/registry-create.ipynb
@@ -152,9 +152,7 @@
     "registry.name = \"DemoRegistryPython\" + \"-\" + ts\n",
     "print(f\"the registry name: {registry.name}\")\n",
     "\n",
-    "registry = ml_client.registries.begin_create(registry=registry).result(\n",
-    "    timeout=LROConfigurations.POLLING_TIMEOUT\n",
-    ")"
+    "registry = ml_client.registries.begin_create(registry=registry).wait()"
    ]
   },
   {


### PR DESCRIPTION
# Description
Registry creation notebook fails because 720 seconds (LROConfigurations.POLLING_TIMEOUT) is not enough to deploy the registry and that results intofailure. See work item 3299522.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
