### PR TITLE
[bugfix] Upgrade curated environment tf from 2.11 to 2.16

### DIFF
--- a/cli/jobs/pipelines-with-components/basics/6a_tf_hello_world/component.yml
+++ b/cli/jobs/pipelines-with-components/basics/6a_tf_hello_world/component.yml
@@ -7,7 +7,7 @@ name: tf_hello_world
 display_name: TF-hello-world
 version: 1
 
-environment: azureml://registries/azureml/environments/tensorflow-2.12-cuda11/labels/latest
+environment: azureml://registries/azureml/environments/tensorflow-2.16-cuda11/labels/latest
 command: echo $TF_CONFIG
 resources:
   instance_count: 2

--- a/cli/jobs/pipelines/tensorflow-image-segmentation/pipeline.yml
+++ b/cli/jobs/pipelines/tensorflow-image-segmentation/pipeline.yml
@@ -44,7 +44,7 @@ jobs:
       type: tensorflow
       worker_count: 1 # needs to match instance_count (!)
 
-    environment: azureml://registries/azureml/environments/tensorflow-2.12-cuda11/labels/latest
+    environment: azureml://registries/azureml/environments/tensorflow-2.16-cuda11/labels/latest
     # uncomment below to use custom environment
     # environment:
     #   build: 

--- a/cli/jobs/pipelines/tensorflow-image-segmentation/src/tf_helper/training.py
+++ b/cli/jobs/pipelines/tensorflow-image-segmentation/src/tf_helper/training.py
@@ -363,7 +363,7 @@ class TensorflowDistributedModelTrainingSequence:
         self.model = model
 
         params_count = np.sum(
-            [np.prod(v.get_shape()) for v in self.model.trainable_weights]
+            [np.prod(v.shape.as_list()) for v in self.model.trainable_weights]
         )
         self.logger.info(
             "MLFLOW: model_param_count={:.2f} (millions)".format(


### PR DESCRIPTION
# Description

Curated environment `tensorflow-2.12-cuda11` reaches EOL, so upgrade it to use later environment 2.16 version.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
