### PR TITLE
update OneHotEncoder arg sparse to sparse_output

### DIFF
--- a/sdk/python/responsible-ai/tabular/responsibleaidashboard-programmer-regression-model-debugging/responsibleaidashboard-programmer-regression-model-debugging.ipynb
+++ b/sdk/python/responsible-ai/tabular/responsibleaidashboard-programmer-regression-model-debugging/responsibleaidashboard-programmer-regression-model-debugging.ipynb
@@ -353,7 +353,7 @@
     "    ])\n",
     "    cat_pipe = Pipeline([\n",
     "        ('cat_imputer', SimpleImputer(strategy='constant', fill_value='?')),\n",
-    "        ('cat_encoder', OneHotEncoder(handle_unknown='ignore', sparse=False))\n",
+    "        ('cat_encoder', OneHotEncoder(handle_unknown='ignore', sparse_output=False))\n",
     "    ])\n",
     "    feat_pipe = ColumnTransformer([\n",
     "        ('num_pipe', num_pipe, pipe_cfg['num_cols']),\n",


### PR DESCRIPTION
# Description
Added in version 1.2, OneHotEncoder argument `sparse` was renamed to `sparse_output`. Correct notebook accordingly. 

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
