### PR TITLE
Zetia/fix K8s onlinedeployment vulnerability issue

### DIFF
--- a/cli/endpoints/online/kubernetes/kubernetes-blue-deployment.yml
+++ b/cli/endpoints/online/kubernetes/kubernetes-blue-deployment.yml
@@ -9,7 +9,7 @@ code_configuration:
   scoring_script: score.py
 environment: 
   conda_file: ../model-1/environment/conda.yaml
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest
+  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:latest
 request_settings:
   request_timeout_ms: 3000
   max_queue_wait_ms: 3000

--- a/cli/endpoints/online/kubernetes/kubernetes-green-deployment.yml
+++ b/cli/endpoints/online/kubernetes/kubernetes-green-deployment.yml
@@ -10,7 +10,7 @@ code_configuration:
   scoring_script: score.py
 environment:
   conda_file: ../model-2/environment/conda.yaml
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest
+  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:latest
 instance_type: defaultinstancetype
 resources:
   requests:

--- a/cli/endpoints/online/model-1/environment/conda.yaml
+++ b/cli/endpoints/online/model-1/environment/conda.yaml
@@ -8,6 +8,6 @@ dependencies:
   - scikit-learn=1.2.2
   - scipy=1.10.1
   - pip:
-    - azureml-defaults==1.53.0
+    - azureml-defaults==1.56.0.post1
     - inference-schema[numpy-support]==1.5.1
     - joblib==1.2.0

--- a/cli/endpoints/online/model-1/environment/conda.yaml
+++ b/cli/endpoints/online/model-1/environment/conda.yaml
@@ -9,5 +9,5 @@ dependencies:
   - scipy=1.10.1
   - pip:
     - azureml-defaults==1.56.0.post1
-    - inference-schema[numpy-support]==1.5.1
+    - inference-schema[numpy-support]==1.7
     - joblib==1.2.0

--- a/cli/endpoints/online/model-2/environment/conda.yaml
+++ b/cli/endpoints/online/model-2/environment/conda.yaml
@@ -8,6 +8,6 @@ dependencies:
   - scikit-learn=1.2.2
   - scipy=1.10.1
   - pip:
-    - azureml-defaults==1.53.0
+    - azureml-defaults==1.56.0.post1
     - inference-schema[numpy-support]==1.5.1
     - joblib==1.2.0

--- a/cli/endpoints/online/model-2/environment/conda.yaml
+++ b/cli/endpoints/online/model-2/environment/conda.yaml
@@ -9,5 +9,5 @@ dependencies:
   - scipy=1.10.1
   - pip:
     - azureml-defaults==1.56.0.post1
-    - inference-schema[numpy-support]==1.5.1
+    - inference-schema[numpy-support]==1.7
     - joblib==1.2.0


### PR DESCRIPTION
# Description

1. To fix this vulnerability(https://github.com/advisories/GHSA-5wvp-7f3h-6wmm), I upgraded azureml-defaults and inference-schema[numpy-support] packages
2. I also upgraded base image from ubuntu20.04 to ubuntu22.04.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
