### PR TITLE
Datagen clarify endpoint URL format + removed unused pip installs

### DIFF
--- a/sdk/python/foundation-models/system/finetune/Llama-notebooks/datagen/synthetic-data-generation.ipynb
+++ b/sdk/python/foundation-models/system/finetune/Llama-notebooks/datagen/synthetic-data-generation.ipynb
@@ -35,10 +35,7 @@
    "source": [
     "%pip install azure-ai-ml\n",
     "%pip install azure-identity\n",
-    "%pip install datasets\n",
-    "%pip install mlflow\n",
-    "%pip install azureml-mlflow\n",
-    "%pip install fsspec"
+    "%pip install datasets"
    ],
    "outputs": [],
    "execution_count": null,

--- a/sdk/python/foundation-models/system/finetune/Llama-notebooks/datagen/synthetic-data-generation.ipynb
+++ b/sdk/python/foundation-models/system/finetune/Llama-notebooks/datagen/synthetic-data-generation.ipynb
@@ -307,8 +307,11 @@
    "source": [
     "from utils import AzureInference\n",
     "\n",
-    "url = \"<Chat completion teacher model endpoint URL>\"\n",
-    "key = \"<API key>\"\n",
+    "# The `url` can be copied from the `Deployments` > `Consume` tab in the `URL Endpoint` field.\n",
+    "url = \"https://<CHAT_TEACHER_MODEL_DEPLOYMENT_NAME>.<REGION>.models.ai.azure.com/v1/chat/completions\"\n",
+    "\n",
+    "#  The `key` can be copied from the `Deployments` > `Details` tab in the `Endpoint` > `Key` field.\n",
+    "key = \"<API_KEY>\"\n",
     "\n",
     "az_llama_405b_model_inf = AzureInference(url=url, key=key)"
    ],


### PR DESCRIPTION
# Description

The notebook contains pip installs which are not necessary for its execution and fail on MacOS:
- `datasets`
- `mlflow`
- `azure-mlflow`

This PR removes those.

This PR also clarifies the format of the teacher model endpoint URL and explains where to find it in Azure AI Studio.

Tested on MacOS 14.5 (23F79) Apple Silicon M2 local with Python 3.8.19

# Checklist

- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ x Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
