### PR TITLE
fix(ci): Add workaround to circumvent azure-cli's lack of support for ID token refresh

### DIFF
--- a/.github/workflows/cli-assets-component-pipeline.yml
+++ b/.github/workflows/cli-assets-component-pipeline.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/component"

--- a/.github/workflows/cli-assets-component-train.yml
+++ b/.github/workflows/cli-assets-component-train.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/component"

--- a/.github/workflows/cli-assets-data-cloud-file-https.yml
+++ b/.github/workflows/cli-assets-data-cloud-file-https.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-cloud-file-wasbs.yml
+++ b/.github/workflows/cli-assets-data-cloud-file-wasbs.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-cloud-file.yml
+++ b/.github/workflows/cli-assets-data-cloud-file.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-cloud-folder-https.yml
+++ b/.github/workflows/cli-assets-data-cloud-folder-https.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-cloud-folder.yml
+++ b/.github/workflows/cli-assets-data-cloud-folder.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-cloud-mltable.yml
+++ b/.github/workflows/cli-assets-data-cloud-mltable.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-iris-csv-example.yml
+++ b/.github/workflows/cli-assets-data-iris-csv-example.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-local-file.yml
+++ b/.github/workflows/cli-assets-data-local-file.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-local-folder-sampledata.yml
+++ b/.github/workflows/cli-assets-data-local-folder-sampledata.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-local-folder.yml
+++ b/.github/workflows/cli-assets-data-local-folder.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-local-mltable.yml
+++ b/.github/workflows/cli-assets-data-local-mltable.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-data-public-file-https.yml
+++ b/.github/workflows/cli-assets-data-public-file-https.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/data"

--- a/.github/workflows/cli-assets-environment-docker-context.yml
+++ b/.github/workflows/cli-assets-environment-docker-context.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/environment"

--- a/.github/workflows/cli-assets-environment-docker-image.yml
+++ b/.github/workflows/cli-assets-environment-docker-image.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/environment"

--- a/.github/workflows/cli-assets-model-local-file.yml
+++ b/.github/workflows/cli-assets-model-local-file.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/model"

--- a/.github/workflows/cli-assets-model-local-mlflow.yml
+++ b/.github/workflows/cli-assets-model-local-mlflow.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/assets/model"

--- a/.github/workflows/cli-endpoints-batch-deploy-models-custom-outputs-parquet-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-custom-outputs-parquet-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-models/custom-outputs-parquet"

--- a/.github/workflows/cli-endpoints-batch-deploy-models-heart-classifier-mlflow-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-heart-classifier-mlflow-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-models/heart-classifier-mlflow"

--- a/.github/workflows/cli-endpoints-batch-deploy-models-huggingface-text-summarization-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-huggingface-text-summarization-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-models/huggingface-text-summarization"

--- a/.github/workflows/cli-endpoints-batch-deploy-models-imagenet-classifier-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-imagenet-classifier-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-models/imagenet-classifier"

--- a/.github/workflows/cli-endpoints-batch-deploy-models-mnist-classifier-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-mnist-classifier-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-models/mnist-classifier"

--- a/.github/workflows/cli-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing"

--- a/.github/workflows/cli-endpoints-batch-deploy-pipelines-hello-batch-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-pipelines-hello-batch-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-pipelines/hello-batch"

--- a/.github/workflows/cli-endpoints-batch-deploy-pipelines-training-with-components-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-pipelines-training-with-components-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/batch/deploy-pipelines/training-with-components"

--- a/.github/workflows/cli-endpoints-online-custom-container-minimal-multimodel-minimal-multimodel-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-minimal-multimodel-minimal-multimodel-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/custom-container/minimal/multimodel"

--- a/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-conda-in-dockerfile-minimal-single-model-conda-in-dockerfile-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-conda-in-dockerfile-minimal-single-model-conda-in-dockerfile-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/custom-container/minimal/single-model/conda-in-dockerfile"

--- a/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-minimal-single-model-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-minimal-single-model-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/custom-container/minimal/single-model"

--- a/.github/workflows/cli-endpoints-online-custom-container-mlflow-multideployment-scikit-mlflow-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-mlflow-multideployment-scikit-mlflow-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/custom-container/mlflow/multideployment-scikit"

--- a/.github/workflows/cli-endpoints-online-custom-container-r-multimodel-plumber-r-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-r-multimodel-plumber-r-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/custom-container/r/multimodel-plumber"

--- a/.github/workflows/cli-endpoints-online-custom-container-torchserve-densenet-torchserve-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-torchserve-densenet-torchserve-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/custom-container/torchserve/densenet"

--- a/.github/workflows/cli-endpoints-online-custom-container-triton-single-model-triton-cc-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-triton-single-model-triton-cc-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/custom-container/triton/single-model"

--- a/.github/workflows/cli-endpoints-online-kubernetes-kubernetes-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-kubernetes-kubernetes-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/kubernetes"

--- a/.github/workflows/cli-endpoints-online-managed-sample-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-managed-sample-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/managed/sample"

--- a/.github/workflows/cli-endpoints-online-managed-vnet-mlflow-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-managed-vnet-mlflow-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/managed/vnet/mlflow"

--- a/.github/workflows/cli-endpoints-online-managed-vnet-sample-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-managed-vnet-sample-endpoint.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/endpoints/online/managed/vnet/sample"

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-classification-task-bankmarketing-cli-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-classification-task-bankmarketing-cli-automl-classification-task-bankmarketing.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-bike-share-cli-automl-forecasting-task-bike-share.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-bike-share-cli-automl-forecasting-task-bike-share.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-orange-juice-sales-cli-automl-forecasting-orange-juice-sales.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-orange-juice-sales-cli-automl-forecasting-orange-juice-sales.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-energy-demand-cli-automl-forecasting-task-energy-demand.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-energy-demand-cli-automl-forecasting-task-energy-demand.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-github-dau-cli-automl-forecasting-task-github-dau.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-github-dau-cli-automl-forecasting-task-github-dau.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items-automode.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items-automode.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items-automode.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items-automode.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-regression-task-hardware-perf-cli-automl-regression-task-hardware-perf.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-regression-task-hardware-perf-cli-automl-regression-task-hardware-perf.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-multilabel-paper-cat-cli-automl-text-classification-multilabel-paper-cat.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-multilabel-paper-cat-cli-automl-text-classification-multilabel-paper-cat.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-newsgroup-cli-automl-text-classification-newsgroup.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-newsgroup-cli-automl-text-classification-newsgroup.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-cli-automl-text-ner-conll2003.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-cli-automl-text-ner-conll2003.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-distributed-sweeping-cli-automl-text-ner-conll2003-distributed-sweeping.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-distributed-sweeping-cli-automl-text-ner-conll2003-distributed-sweeping.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-automl-hello-automl-job-basic.yml
+++ b/.github/workflows/cli-jobs-basics-hello-automl-hello-automl-job-basic.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-code.yml
+++ b/.github/workflows/cli-jobs-basics-hello-code.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-data-uri-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-data-uri-folder.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-dataset.yml
+++ b/.github/workflows/cli-jobs-basics-hello-dataset.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-git.yml
+++ b/.github/workflows/cli-jobs-basics-hello-git.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-interactive.yml
+++ b/.github/workflows/cli-jobs-basics-hello-interactive.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-iris-datastore-file.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-datastore-file.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-iris-datastore-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-datastore-folder.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-iris-file.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-file.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-iris-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-folder.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-iris-literal.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-literal.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-mlflow.yml
+++ b/.github/workflows/cli-jobs-basics-hello-mlflow.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-model-as-input.yml
+++ b/.github/workflows/cli-jobs-basics-hello-model-as-input.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-model-as-output.yml
+++ b/.github/workflows/cli-jobs-basics-hello-model-as-output.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-notebook.yml
+++ b/.github/workflows/cli-jobs-basics-hello-notebook.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-abc.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-abc.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-file.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-file.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-folder.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-default-artifacts.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-default-artifacts.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-io.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-io.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-settings.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-settings.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-pipeline.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-sweep.yml
+++ b/.github/workflows/cli-jobs-basics-hello-sweep.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-world-env-var.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-env-var.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-world-input.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-input.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-world-org.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-org.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-world-output-data.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-output-data.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-world-output.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-output.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-basics-hello-world.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-deepspeed-deepspeed-autotuning-job.yml
+++ b/.github/workflows/cli-jobs-deepspeed-deepspeed-autotuning-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-deepspeed-deepspeed-training-job.yml
+++ b/.github/workflows/cli-jobs-deepspeed-deepspeed-training-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-nebulaml-PyTorch_CNN_MNIST-job.yml
+++ b/.github/workflows/cli-jobs-nebulaml-PyTorch_CNN_MNIST-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-parallel-1a_oj_sales_prediction-pipeline.yml
+++ b/.github/workflows/cli-jobs-parallel-1a_oj_sales_prediction-pipeline.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-parallel-2a_iris_batch_prediction-pipeline.yml
+++ b/.github/workflows/cli-jobs-parallel-2a_iris_batch_prediction-pipeline.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-parallel-3a_mnist_batch_identification-pipeline.yml
+++ b/.github/workflows/cli-jobs-parallel-3a_mnist_batch_identification-pipeline.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-classification-task-bankmarketing-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-classification-task-bankmarketing-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-regression-housepricing-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-regression-housepricing-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-multilabel-paper-categorization-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-multilabel-paper-categorization-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-newsgroup-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-newsgroup-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-ner-conll-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-ner-conll-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-image-instance-segmentation-task-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-instance-segmentation-task-fridge-items-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-image-multiclass-classification-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-multiclass-classification-fridge-items-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-image-multilabel-classification-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-multilabel-classification-fridge-items-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-automl-image-object-detection-task-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-object-detection-task-fridge-items-pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-cifar-10-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-cifar-10-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-iris-batch-prediction-using-parallel-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-iris-batch-prediction-using-parallel-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-mnist-batch-identification-using-parallel-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-mnist-batch-identification-using-parallel-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-nyc-taxi-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-nyc-taxi-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-tensorflow-image-segmentation-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-tensorflow-image-segmentation-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/1a_e2e_local_components"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/1b_e2e_registered_components"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/2a_basic_component"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/2b_component_with_input_output"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/3a_basic_pipeline"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/3b_pipeline_with_data"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/4a_local_data_input"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/4b_datastore_datapath_uri"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/4c_web_url_input"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/4d_data_input"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/5a_env_public_docker_image"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/5b_env_registered"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/5c_env_conda_file"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/6a_tf_hello_world"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/6b_pytorch_hello_world"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline-registry.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/jobs/pipelines-with-components/basics/6c_r_iris"

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-image_classification_with_densenet-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-image_classification_with_densenet-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-single-job-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-single-job-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_job_with_flow_as_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_job_with_flow_as_component-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_hyperparameter_sweep-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_hyperparameter_sweep-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-dask-nyctaxi-job.yml
+++ b/.github/workflows/cli-jobs-single-step-dask-nyctaxi-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-gpu_perf-gpu_perf_job.yml
+++ b/.github/workflows/cli-jobs-single-step-gpu_perf-gpu_perf_job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-julia-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-julia-iris-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-lightgbm-iris-job-sweep.yml
+++ b/.github/workflows/cli-jobs-single-step-lightgbm-iris-job-sweep.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-lightgbm-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-lightgbm-iris-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-pytorch-cifar-distributed-job.yml
+++ b/.github/workflows/cli-jobs-single-step-pytorch-cifar-distributed-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-pytorch-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-pytorch-iris-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-pytorch-word-language-model-job.yml
+++ b/.github/workflows/cli-jobs-single-step-pytorch-word-language-model-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-r-accidents-job.yml
+++ b/.github/workflows/cli-jobs-single-step-r-accidents-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-r-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-r-iris-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-diabetes-job.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-diabetes-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-docker-context.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-docker-context.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-sweep.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-sweep.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-notebook-job.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-notebook-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-tensorflow-mnist-distributed-horovod-job.yml
+++ b/.github/workflows/cli-jobs-single-step-tensorflow-mnist-distributed-horovod-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-tensorflow-mnist-distributed-job.yml
+++ b/.github/workflows/cli-jobs-single-step-tensorflow-mnist-distributed-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-single-step-tensorflow-mnist-job.yml
+++ b/.github/workflows/cli-jobs-single-step-tensorflow-mnist-job.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-jobs-spark-attached-spark-pipeline-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-pipeline-default-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-attached-spark-pipeline-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-pipeline-managed-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-attached-spark-pipeline-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-pipeline-user-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-attached-spark-standalone-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-standalone-default-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-attached-spark-standalone-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-standalone-managed-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-attached-spark-standalone-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-standalone-user-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-default-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-managed-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-user-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-serverless-spark-standalone-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-standalone-default-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-serverless-spark-standalone-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-standalone-managed-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-jobs-spark-serverless-spark-standalone-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-standalone-user-identity.yml
@@ -47,6 +47,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: upload data
       run: |
           bash -x upload-data-to-blob.sh jobs/spark/

--- a/.github/workflows/cli-resources-compute-cluster-basic.yml
+++ b/.github/workflows/cli-resources-compute-cluster-basic.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/resources/compute"

--- a/.github/workflows/cli-resources-compute-cluster-location.yml
+++ b/.github/workflows/cli-resources-compute-cluster-location.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/resources/compute"

--- a/.github/workflows/cli-resources-compute-cluster-low-priority.yml
+++ b/.github/workflows/cli-resources-compute-cluster-low-priority.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/resources/compute"

--- a/.github/workflows/cli-resources-compute-cluster-minimal.yml
+++ b/.github/workflows/cli-resources-compute-cluster-minimal.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/resources/compute"

--- a/.github/workflows/cli-resources-compute-cluster-ssh-password.yml
+++ b/.github/workflows/cli-resources-compute-cluster-ssh-password.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/resources/compute"

--- a/.github/workflows/cli-resources-compute-cluster-system-identity.yml
+++ b/.github/workflows/cli-resources-compute-cluster-system-identity.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/resources/compute"

--- a/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-housing-classification-cli-responsibleaidashboard-housing-classification.yml
+++ b/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-housing-classification-cli-responsibleaidashboard-housing-classification.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-programmer-regression-cli-responsibleaidashboard-programmer-regression.yml
+++ b/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-programmer-regression-cli-responsibleaidashboard-programmer-regression.yml
@@ -46,6 +46,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run job
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/cli-schedules-schedules-cron-job-schedule.yml
+++ b/.github/workflows/cli-schedules-schedules-cron-job-schedule.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/schedules"

--- a/.github/workflows/cli-schedules-schedules-cron-with-settings-job-schedule.yml
+++ b/.github/workflows/cli-schedules-schedules-cron-with-settings-job-schedule.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/schedules"

--- a/.github/workflows/cli-schedules-schedules-recurrence-job-schedule.yml
+++ b/.github/workflows/cli-schedules-schedules-recurrence-job-schedule.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/schedules"

--- a/.github/workflows/cli-scripts-batch-score-rest.yml
+++ b/.github/workflows/cli-scripts-batch-score-rest.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-batch-score.yml
+++ b/.github/workflows/cli-scripts-batch-score.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-minimal-multimodel.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-minimal-multimodel.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-minimal-single-model.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-minimal-single-model.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-mlflow-multideployment-scikit.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-mlflow-multideployment-scikit.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-r-multimodel-plumber.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-r-multimodel-plumber.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two-integrated.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two-integrated.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-torchserve-densenet.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-torchserve-densenet.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-torchserve-huggingface-textgen.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-torchserve-huggingface-textgen.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-custom-container-triton-single-model.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-triton-single-model.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-local-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-local-endpoint.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-ncd.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-ncd.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-mlcompute-create_with-system-identity.yml
+++ b/.github/workflows/cli-scripts-deploy-mlcompute-create_with-system-identity.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-mlcompute-update-to-system-identity.yml
+++ b/.github/workflows/cli-scripts-deploy-mlcompute-update-to-system-identity.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-mlcompute-update-to-user-identity.yml
+++ b/.github/workflows/cli-scripts-deploy-mlcompute-update-to-user-identity.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-moe-binary-payloads.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-binary-payloads.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-moe-inference-schema.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-inference-schema.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-moe-keyvault.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-keyvault.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-moe-minimal-single-model-registered.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-minimal-single-model-registered.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-moe-openapi.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-openapi.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-rest.yml
+++ b/.github/workflows/cli-scripts-deploy-rest.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-deploy-triton-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-triton-managed-online-endpoint.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-misc.yml
+++ b/.github/workflows/cli-scripts-misc.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-mlflow-uri.yml
+++ b/.github/workflows/cli-scripts-mlflow-uri.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-train-rest.yml
+++ b/.github/workflows/cli-scripts-train-rest.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/cli-scripts-train.yml
+++ b/.github/workflows/cli-scripts-train.yml
@@ -45,6 +45,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "${{ github.workspace }}/cli/"

--- a/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run assets/assets-in-registry/share-data-using-registry.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run assets/assets-in-registry/share-models-components-environments.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-assets-component-component.yml
+++ b/.github/workflows/sdk-assets-component-component.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run assets/component/component.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-assets-data-data.yml
+++ b/.github/workflows/sdk-assets-data-data.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run assets/data/data.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-assets-data-working_with_mltable.yml
+++ b/.github/workflows/sdk-assets-data-working_with_mltable.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run assets/data/working_with_mltable.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-assets-environment-environment.yml
+++ b/.github/workflows/sdk-assets-environment-environment.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run assets/environment/environment.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-assets-model-model.yml
+++ b/.github/workflows/sdk-assets-model-model.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run assets/model/model.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-custom-outputs-parquet-custom-output-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-custom-outputs-parquet-custom-output-batch.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-heart-classifier-mlflow-mlflow-for-batch-tabular.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-heart-classifier-mlflow-mlflow-for-batch-tabular.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-huggingface-text-summarization-text-summarization-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-huggingface-text-summarization-text-summarization-batch.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-batch.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-mlflow.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-mlflow.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-mlflow.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-mnist-classifier-mnist-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-mnist-classifier-mnist-batch.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-models/mnist-classifier/mnist-batch.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-sdk-deploy-and-test.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-sdk-deploy-and-test.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-pipelines-hello-batch-sdk-deploy-and-test.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-pipelines-hello-batch-sdk-deploy-and-test.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-batch-deploy-pipelines-training-with-components-sdk-deploy-and-test.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-pipelines-training-with-components-sdk-deploy-and-test.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/batch/deploy-pipelines/training-with-components/sdk-deploy-and-test.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/custom-container/online-endpoints-custom-container-multimodel.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/custom-container/online-endpoints-custom-container.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/custom-container/triton/online-endpoints-triton-cc.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-safe-rollout.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/kubernetes/kubernetes-online-endpoints-safe-rollout.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-simple-deployment.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/kubernetes/kubernetes-online-endpoints-simple-deployment.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-llm-langchain-1_langchain_basic_deploy.yml
+++ b/.github/workflows/sdk-endpoints-online-llm-langchain-1_langchain_basic_deploy.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/llm/langchain/1_langchain_basic_deploy.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-llm-semantic-kernel-1_semantic_http_server.yml
+++ b/.github/workflows/sdk-endpoints-online-llm-semantic-kernel-1_semantic_http_server.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/llm/semantic-kernel/1_semantic_http_server.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/managed-identities/online-endpoints-managed-identity-sai.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/online-endpoints-binary-payloads.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/online-endpoints-inference-schema.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/online-endpoints-keyvault.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/online-endpoints-multimodel.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/online-endpoints-openapi.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/online-endpoints-safe-rollout.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/managed/online-endpoints-simple-deployment.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model-with-script.yml
+++ b/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model-with-script.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/mlflow/online-endpoints-deploy-mlflow-model-with-script.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
+++ b/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/mlflow/online-endpoints-deploy-mlflow-model.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
+++ b/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run endpoints/online/triton/single-model/online-endpoints-triton.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-foundation-models-azure_openai-oai-v1-openai_completions_finetune.yml
+++ b/.github/workflows/sdk-foundation-models-azure_openai-oai-v1-openai_completions_finetune.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run foundation-models/azure_openai/oai-v1/openai_completions_finetune.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-foundation-models-huggingface-inference-question-answering-question-answering-online-endpoint.yml
+++ b/.github/workflows/sdk-foundation-models-huggingface-inference-question-answering-question-answering-online-endpoint.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run foundation-models/huggingface/inference/question-answering/question-answering-online-endpoint.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-foundation-models-huggingface-inference-token-classification-token-classification-online-endpoint.yml
+++ b/.github/workflows/sdk-foundation-models-huggingface-inference-token-classification-token-classification-online-endpoint.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run foundation-models/huggingface/inference/token-classification/token-classification-online-endpoint.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-foundation-models-huggingface-inference-translation-translation-online-endpoint.yml
+++ b/.github/workflows/sdk-foundation-models-huggingface-inference-translation-translation-online-endpoint.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run foundation-models/huggingface/inference/translation/translation-online-endpoint.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-foundation-models-huggingface-inference-zero-shot-classification-zero-shot-classification-online-endpoint.yml
+++ b/.github/workflows/sdk-foundation-models-huggingface-inference-zero-shot-classification-zero-shot-classification-online-endpoint.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run foundation-models/huggingface/inference/zero-shot-classification/zero-shot-classification-online-endpoint.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry.yml
+++ b/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run foundation-models/system/import/import_model_into_registry.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-classification-task-bankmarketing/automl-classification-task-bankmarketing.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-distributed-tcn-automl-forecasting-distributed-tcn.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-distributed-tcn-automl-forecasting-distributed-tcn.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-distributed-tcn/automl-forecasting-distributed-tcn.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
@@ -72,6 +72,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-github-dau/auto-ml-forecasting-github-dau.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
@@ -72,6 +72,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-orange-juice-sales/automl-forecasting-orange-juice-sales-mlflow.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-experiment-settings.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-experiment-settings.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-recipes-univariate/automl-forecasting-recipe-univariate-experiment-settings.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-run.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-run.yml
@@ -72,6 +72,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-recipes-univariate/automl-forecasting-recipe-univariate-run.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
@@ -72,6 +72,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-task-bike-share/auto-ml-forecasting-bike-share.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
@@ -72,6 +72,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced-mlflow.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-forecasting-task-energy-demand/automl-forecasting-task-energy-demand-advanced.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-image-classification-multiclass-task-fridge-items/automl-image-classification-multiclass-task-fridge-items.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-image-classification-multilabel-task-fridge-items/automl-image-classification-multilabel-task-fridge-items.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment-mlflow.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-nlp-text-classification-multiclass-task-sentiment-analysis/automl-nlp-multiclass-sentiment.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-nlp-text-classification-multilabel-task-paper-categorization/automl-nlp-multilabel-paper-cat.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task/automl-nlp-text-ner-task.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-nlp-text-named-entity-recognition-task-distributed-sweeping/automl-nlp-text-ner-task-distributed-with-sweeping.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/automl-standalone-jobs/automl-regression-task-hardware-performance/automl-regression-task-hardware-performance.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-configuration.yml
+++ b/.github/workflows/sdk-jobs-configuration.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/configuration.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-parallel-1a_oj_sales_prediction-oj_sales_prediction.yml
+++ b/.github/workflows/sdk-jobs-parallel-1a_oj_sales_prediction-oj_sales_prediction.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/parallel/1a_oj_sales_prediction/oj_sales_prediction.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-parallel-2a_iris_batch_prediction-iris_batch_prediction.yml
+++ b/.github/workflows/sdk-jobs-parallel-2a_iris_batch_prediction-iris_batch_prediction.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/parallel/2a_iris_batch_prediction/iris_batch_prediction.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-parallel-3a_mnist_batch_identification-mnist_batch_prediction.yml
+++ b/.github/workflows/sdk-jobs-parallel-3a_mnist_batch_identification-mnist_batch_prediction.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/parallel/3a_mnist_batch_identification/mnist_batch_prediction.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1a_pipeline_with_components_from_yaml/pipeline_with_components_from_yaml.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1b_pipeline_with_python_function_components/pipeline_with_python_function_components.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1d_pipeline_with_non_python_components/pipeline_with_non_python_components.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1e_pipeline_with_registered_components/pipeline_with_registered_components.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-classification-bankmarketing-in-pipeline/automl-classification-bankmarketing-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-forecasting-in-pipeline/automl-forecasting-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multiclass-in-pipeline/automl-image-classification-multiclass-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-image-classification-multilabel-in-pipeline/automl-image-classification-multilabel-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-image-instance-segmentation-in-pipeline/automl-image-instance-segmentation-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-image-object-detection-in-pipeline/automl-image-object-detection-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-regression-house-pricing-in-pipeline/automl-regression-house-pricing-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-in-pipeline-automl-text-classification-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-in-pipeline-automl-text-classification-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-in-pipeline/automl-text-classification-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-in-pipeline-automl-text-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-in-pipeline-automl-text-classification-multilabel-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-text-classification-multilabel-in-pipeline/automl-text-classification-multilabel-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1h_automl_in_pipeline/automl-text-ner-named-entity-recognition-in-pipeline/automl-text-ner-named-entity-recognition-in-pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: setup spark resources
       run: |
           bash -x jobs/spark/setup_spark.sh jobs/spark/ jobs/pipelines/1i_pipeline_with_spark_nodes/pipeline_with_spark_nodes.ipynb

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1j_pipeline_with_pipeline_component/nyc_taxi_data_regression_with_pipeline_component/nyc_taxi_data_regression_with_pipeline_component.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1j_pipeline_with_pipeline_component/pipeline_with_train_eval_pipeline_component/pipeline_with_train_eval_pipeline_component.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/1l_flow_in_pipeline/flow_in_pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/2a_train_mnist_with_tensorflow/train_mnist_with_tensorflow.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/2b_train_cifar_10_with_pytorch/train_cifar_10_with_pytorch.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/2c_nyc_taxi_data_regression/nyc_taxi_data_regression.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/2d_image_classification_with_densenet/image_classification_with_densenet.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/pipelines/2e_image_classification_keras_minist_convnet/image_classification_keras_minist_convnet.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-debug-and-monitor-debug-and-monitor.yml
+++ b/.github/workflows/sdk-jobs-single-step-debug-and-monitor-debug-and-monitor.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/debug-and-monitor/debug-and-monitor.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
+++ b/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/lightgbm/iris/lightgbm-iris-sweep.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-distributed-cifar10.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-distributed-cifar10.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/pytorch/distributed-training/distributed-cifar10.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-yolov5-objectdetectionAzureML.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-yolov5-objectdetectionAzureML.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/pytorch/distributed-training-yolov5/objectdetectionAzureML.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-iris-pytorch-iris.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/pytorch/iris/pytorch-iris.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/pytorch/train-hyperparameter-tune-deploy-with-pytorch/train-hyperparameter-tune-deploy-with-pytorch.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
+++ b/.github/workflows/sdk-jobs-single-step-r-accidents-accident-prediction.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/r/accidents/accident-prediction.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-diabetes-sklearn-diabetes.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/scikit-learn/diabetes/sklearn-diabetes.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-iris-iris-scikit-learn.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/scikit-learn/iris/iris-scikit-learn.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-scikit-learn-mnist-sklearn-mnist.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/scikit-learn/mnist/sklearn-mnist.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-horovod-tensorflow-mnist-distributed-horovod.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/tensorflow/mnist-distributed-horovod/tensorflow-mnist-distributed-horovod.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/tensorflow/mnist-distributed/tensorflow-mnist-distributed.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-tensorflow-mnist.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run jobs/single-step/tensorflow/mnist/tensorflow-mnist.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-jobs-spark-automation-run_interactive_session_notebook.yml
+++ b/.github/workflows/sdk-jobs-spark-automation-run_interactive_session_notebook.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: setup spark resources
       run: |
           bash -x jobs/spark/setup_spark.sh jobs/spark/ jobs/spark/automation/run_interactive_session_notebook.ipynb

--- a/.github/workflows/sdk-jobs-spark-submit_spark_pipeline_jobs.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_pipeline_jobs.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: setup spark resources
       run: |
           bash -x jobs/spark/setup_spark.sh jobs/spark/ jobs/spark/submit_spark_pipeline_jobs.ipynb

--- a/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: setup spark resources
       run: |
           bash -x jobs/spark/setup_spark.sh jobs/spark/ jobs/spark/submit_spark_standalone_jobs.ipynb

--- a/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: setup spark resources
       run: |
           bash -x jobs/spark/setup_spark.sh jobs/spark/ jobs/spark/submit_spark_standalone_jobs_managed_vnet.ipynb

--- a/.github/workflows/sdk-resources-compute-attach_manage_spark_pools.yml
+++ b/.github/workflows/sdk-resources-compute-attach_manage_spark_pools.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: setup spark resources
       run: |
           bash -x jobs/spark/setup_spark.sh jobs/spark/ resources/compute/attach_manage_spark_pools.ipynb

--- a/.github/workflows/sdk-resources-compute-compute.yml
+++ b/.github/workflows/sdk-resources-compute-compute.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run resources/compute/compute.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-resources-connections-connections.yml
+++ b/.github/workflows/sdk-resources-connections-connections.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run resources/connections/connections.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-resources-registry-registry-create.yml
+++ b/.github/workflows/sdk-resources-registry-registry-create.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run resources/registry/registry-create.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-resources-workspace-workspace.yml
+++ b/.github/workflows/sdk-resources-workspace-workspace.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run resources/workspace/workspace.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-mlflow-deployment-with-explanations-mlflow-deployment-with-explanations.yml
+++ b/.github/workflows/sdk-responsible-ai-mlflow-deployment-with-explanations-mlflow-deployment-with-explanations.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/mlflow-deployment-with-explanations/mlflow-deployment-with-explanations.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/tabular/responsibleaidashboard-diabetes-decision-making/responsibleaidashboard-diabetes-decision-making.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/tabular/responsibleaidashboard-diabetes-regression-model-debugging/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-finance-loan-classification-responsibleaidashboard-finance-loan-classification.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-finance-loan-classification-responsibleaidashboard-finance-loan-classification.yml
@@ -64,6 +64,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/tabular/responsibleaidashboard-finance-loan-classification/responsibleaidashboard-finance-loan-classification.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-healthcare-covid-classification-responsibleaidashboard-healthcare-covid-classification.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-healthcare-covid-classification-responsibleaidashboard-healthcare-covid-classification.yml
@@ -64,6 +64,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/tabular/responsibleaidashboard-healthcare-covid-classification/responsibleaidashboard-healthcare-covid-classification.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/tabular/responsibleaidashboard-housing-classification-model-debugging/responsibleaidashboard-housing-classification-model-debugging.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/tabular/responsibleaidashboard-housing-decision-making/responsibleaidashboard-housing-decision-making.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/tabular/responsibleaidashboard-programmer-regression-model-debugging/responsibleaidashboard-programmer-regression-model-debugging.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-multilabel-text-classification-covid-events.yml
+++ b/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-multilabel-text-classification-covid-events.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/text/responsibleaidashboard-multilabel-text-classification-covid-events.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-classification-DBPedia.yml
+++ b/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-classification-DBPedia.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/text/responsibleaidashboard-text-classification-DBPedia.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-classification-blbooksgenre.yml
+++ b/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-classification-blbooksgenre.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-classification-financial-news-responsibleaidashboard-text-classification-financial-news.yml
+++ b/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-classification-financial-news-responsibleaidashboard-text-classification-financial-news.yml
@@ -64,6 +64,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/text/responsibleaidashboard-text-classification-financial-news/responsibleaidashboard-text-classification-financial-news.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-question-answering-squad.yml
+++ b/.github/workflows/sdk-responsible-ai-text-responsibleaidashboard-text-question-answering-squad.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/text/responsibleaidashboard-text-question-answering-squad.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-automl-image-classification-fridge.yml
+++ b/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-automl-image-classification-fridge.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/vision/responsibleaidashboard-automl-image-classification-fridge.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-automl-object-detection-fridge-private-data.yml
+++ b/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-automl-object-detection-fridge-private-data.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/vision/responsibleaidashboard-automl-object-detection-fridge-private-data.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-image-classification-fridge.yml
+++ b/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-image-classification-fridge.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/vision/responsibleaidashboard-image-classification-fridge.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-image-flower-classification.yml
+++ b/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-image-flower-classification.yml
@@ -64,6 +64,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/vision/responsibleaidashboard-image-flower-classification.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-image-multilabel-classification-fridge.yml
+++ b/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-image-multilabel-classification-fridge.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/vision/responsibleaidashboard-image-multilabel-classification-fridge.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-object-detection-MSCOCO.yml
+++ b/.github/workflows/sdk-responsible-ai-vision-responsibleaidashboard-object-detection-MSCOCO.yml
@@ -70,6 +70,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run responsible-ai/vision/responsibleaidashboard-object-detection-MSCOCO.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-schedules-job-schedule.yml
+++ b/.github/workflows/sdk-schedules-job-schedule.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run schedules/job-schedule.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-using-mltable-delimited-files-example-delimited-files-example.yml
+++ b/.github/workflows/sdk-using-mltable-delimited-files-example-delimited-files-example.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run using-mltable/delimited-files-example/delimited-files-example.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-using-mltable-delta-lake-example-delta-lake-example.yml
+++ b/.github/workflows/sdk-using-mltable-delta-lake-example-delta-lake-example.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run using-mltable/delta-lake-example/delta-lake-example.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-using-mltable-from-paths-example-from-paths-example.yml
+++ b/.github/workflows/sdk-using-mltable-from-paths-example-from-paths-example.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run using-mltable/from-paths-example/from-paths-example.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-using-mltable-local-to-cloud-mltable-local-to-cloud.yml
+++ b/.github/workflows/sdk-using-mltable-local-to-cloud-mltable-local-to-cloud.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run using-mltable/local-to-cloud/mltable-local-to-cloud.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/sdk-using-mltable-quickstart-mltable-quickstart.yml
+++ b/.github/workflows/sdk-using-mltable-quickstart-mltable-quickstart.yml
@@ -68,6 +68,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run using-mltable/quickstart/mltable-quickstart.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
+++ b/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run azureml-getting-started/azureml-getting-started-studio.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
+++ b/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run azureml-in-a-day/azureml-in-a-day.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
+++ b/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run e2e-distributed-pytorch-image/e2e-object-classification-distributed-pytorch.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
+++ b/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run e2e-ds-experience/e2e-ml-workflow.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run get-started-notebooks/cloud-workstation.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
@@ -67,6 +67,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run get-started-notebooks/deploy-model.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
@@ -67,6 +67,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run get-started-notebooks/explore-data.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run get-started-notebooks/pipeline.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run get-started-notebooks/quickstart.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/.github/workflows/tutorials-get-started-notebooks-train-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-train-model.yml
@@ -69,6 +69,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run get-started-notebooks/train-model.ipynb
       run: |
           source "${{ github.workspace }}/infra/bootstrapping/sdk_helpers.sh";

--- a/cli/readme.py
+++ b/cli/readme.py
@@ -471,7 +471,16 @@ jobs:
           source "{GITHUB_WORKSPACE}/infra/bootstrapping/init_environment.sh";
           bash setup.sh
       working-directory: cli
-      continue-on-error: true\n"""
+      continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none\n"""
     if is_spark_sample:
         workflow_yaml += get_spark_setup_workflow(job, posix_project_dir, filename)
     workflow_yaml += f"""    - name: run job
@@ -556,6 +565,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "{GITHUB_WORKSPACE}/cli/{posix_project_dir}"
@@ -649,6 +667,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "{GITHUB_WORKSPACE}/cli/{project_dir}"
@@ -746,6 +773,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "{GITHUB_WORKSPACE}/cli/{project_dir}"
@@ -812,6 +848,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "{GITHUB_WORKSPACE}/cli/{project_dir}"
@@ -877,6 +922,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: validate readme
       run: |
           python check-readme.py "{GITHUB_WORKSPACE}/cli/{project_dir}"

--- a/sdk/python/readme.py
+++ b/sdk/python/readme.py
@@ -288,7 +288,16 @@ jobs:
           source "{github_workspace}/infra/bootstrapping/init_environment.sh";
           bash setup.sh
       working-directory: cli
-      continue-on-error: true\n"""
+      continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none\n"""
     if is_spark_notebook_sample:
         workflow_yaml += get_spark_config_workflow(posix_folder, name)
     if is_featurestore_sample:

--- a/tutorials/readme.py
+++ b/tutorials/readme.py
@@ -196,6 +196,15 @@ jobs:
           bash setup.sh
       working-directory: cli
       continue-on-error: true
+    - name: Eagerly cache access tokens for required scopes
+      run: |
+          # Workaround for azure-cli's lack of support for ID token refresh
+          # Taken from: https://github.com/Azure/login/issues/372#issuecomment-2056289617
+
+          # Management
+          az account get-access-token --scope https://management.azure.com/.default --output none
+          # ML
+          az account get-access-token --scope https://ml.azure.com/.default --output none
     - name: run {posix_notebook}
       run: |
           source "{github_workspace}/infra/bootstrapping/sdk_helpers.sh";


### PR DESCRIPTION
# Description

This pull request adds a workaround for an issue where some workflows would fail with the following error when requesting an access-token


```
ClientAuthenticationError: ERROR: AADSTS700024: Client assertion is not within its valid time range. Current time: 2024-07-31T13:29:11.3373885Z, assertion valid from 2024-07-31T12:49:53.0000000Z, expiry time of assertion 2024-07-31T12:54:53.0000000Z. Review the documentation at https://learn.microsoft.com/entra/identity-platform/certificate-credentials . Trace ID: 0ff4799d-034f-4a47-a51c-73b333b61a00 Correlation ID: fd15cb9d-734e-4a7c-9d96-0e2069f9c11b Timestamp: 2024-07-31 13:29:11Z
Interactive authentication is needed. Please run:
az login
```

Bugfix for #3253, root cause is likely https://github.com/Azure/login/issues/372

# Background

Workflows in this repository were migrated to federated authentication using OIDC in #3253. 

We've since run into a bug with several workflows similar to the bug described in https://github.com/Azure/login/issues/372: an authentication issue occurs with that authenticate with OIDC after running for sufficiently long.

A comment in the thread includes a collection of workarounds as a stopgap until the root cause is fixed in azure-cli: https://github.com/Azure/login/issues/372#issuecomment-2056289617

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
