### PR TITLE
Fix blbooksgenre notebook failures due to error on deployment

### DIFF
--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"34\""
+    "rai_example_version_string = \"35\""
    ]
   },
   {
@@ -508,7 +508,7 @@
     "        python_model=my_mlflow,\n",
     "        registered_model_name=registered_name,\n",
     "        artifact_path=registered_name,\n",
-    "        pip_requirements=['mlflow', 'torch~=2.0.1', 'transformers>=4.17.0,<4.40.0'])\n",
+    "        pip_requirements=['mlflow', 'torch~=2.0.1', 'transformers>=4.17.0,<=4.44.0'])\n",
     "\n",
     "    _logger.info(\"Writing JSON\")\n",
     "    dict = {\"id\": \"{0}:1\".format(registered_name)}\n",


### PR DESCRIPTION
# Description

Fix blbooksgenre notebook failures due to error on deployment

Seeing error on deployment in notebook:

```
  File "/opt/miniconda/envs/userenv/lib/python3.9/site-packages/azureml_inference_server_http/server/user_script.py", line 77, in load_script
    main_module_spec.loader.exec_module(user_module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/var/mlflow_resources/mlflow_score_script.py", line 378, in <module>
    model = load_model(model_path)
  File "/opt/miniconda/envs/userenv/lib/python3.9/site-packages/mlflow/tracing/provider.py", line 237, in wrapper
    is_func_called, result = True, f(*args, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.9/site-packages/mlflow/pyfunc/__init__.py", line 1027, in load_model
    model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
  File "/opt/miniconda/envs/userenv/lib/python3.9/site-packages/mlflow/pyfunc/model.py", line 550, in _load_pyfunc
    context, python_model, signature = _load_context_model_and_signature(model_path, model_config)
  File "/opt/miniconda/envs/userenv/lib/python3.9/site-packages/mlflow/pyfunc/model.py", line 533, in _load_context_model_and_signature
    python_model = cloudpickle.load(f)
AttributeError: Can't get attribute 'BertSdpaSelfAttention' on <module 'transformers.models.bert.modeling_bert' from '/opt/miniconda/envs/userenv/lib/python3.9/site-packages/transformers/models/bert/modeling_bert.py'>
```

This seems to be related to a new class added to the package which breaks backcompat:
https://github.com/huggingface/transformers/pull/28802

The fix is to increase the bounds on the huggingface transformers pypi package to latest.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
