### PR TITLE
Fix bad installation of tensorflow by pinning protobuf for RAI blbooksgenre notebook

### DIFF
--- a/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb
+++ b/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb
@@ -31,7 +31,8 @@
    "source": [
     "%pip install datasets\n",
     "%pip install ml-wrappers\n",
-    "%pip install \"pandas<2.0.0\""
+    "%pip install \"pandas<2.0.0\"\n",
+    "%pip install \"protobuf<=3.19.6\""
    ]
   },
   {


### PR DESCRIPTION
# Description

Fix bad installation of tensorflow by pinning protobuf for RAI blbooksgenre notebook

Still seeing errors in blbooksgenre notebook like the following, but towards the end of the notebook:

```
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

This seems to be due to a bad installation of tensorflow in the notebook environment - running the notebook in AzureML compute instance seems to work fine.

When looking at the python installation, it looks like originally "protobuf-3.19.6" is installed with tensorflow, but then the "google-api-core<3.0.0,>=1.0.0" package which is a dependency of azure-ai-ml upgrades protobuf to "protobuf-5.27.3", which is not compatible with tensorflow and generates the error message in one of the imports.
The temporary fix for now is to pin protobuf to a valid version.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
