### PR TITLE
chore: Switch to sha256 from md5 to remedy CodeQL Warning

### DIFF
--- a/sdk/python/jobs/single-step/pytorch/distributed-training-yolov5/yolov5/utils/dataloaders.py
+++ b/sdk/python/jobs/single-step/pytorch/distributed-training-yolov5/yolov5/utils/dataloaders.py
@@ -103,7 +103,7 @@ for orientation in ExifTags.TAGS.keys():
 def get_hash(paths):
     # Returns a single hash value of a list of paths (files or dirs)
     size = sum(os.path.getsize(p) for p in paths if os.path.exists(p))  # sizes
-    h = hashlib.md5(str(size).encode())  # hash sizes
+    h = hashlib.sha256(str(size).encode())  # hash sizes
     h.update("".join(paths).encode())  # hash paths
     return h.hexdigest()  # return hash
 


### PR DESCRIPTION
# Description

This pull request migrates from md5 to sha256

https://github.com/Azure/azureml-examples/blob/6a36786a3f8c8d8e1b1b4cf82f1be966eec842df/sdk/python/jobs/single-step/pytorch/distributed-training-yolov5/yolov5/utils/dataloaders.py#L106

CodeQL warns against weak cryptography. This use of md5 doesn't seem to appear in a cryptographically sensitive context, but the easiest remediation for the CodeQL warnings is to switch to an approved hash function.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
