### PR TITLE
Update kubernetes-online-endpoints-simple-deployment.ipynb

### DIFF
--- a/sdk/python/endpoints/online/kubernetes/kubernetes-online-endpoints-simple-deployment.ipynb
+++ b/sdk/python/endpoints/online/kubernetes/kubernetes-online-endpoints-simple-deployment.ipynb
@@ -371,7 +371,7 @@
     "# create an online endpoint\n",
     "endpoint = KubernetesOnlineEndpoint(\n",
     "    name=online_endpoint_name,\n",
-    "    compute=\"<COMPUTE_NAME>\",\n",
+    "    compute=compute_name,\n",
     "    description=\"this is a sample online endpoint\",\n",
     "    auth_mode=\"key\",\n",
     "    tags={\"foo\": \"bar\"},\n",


### PR DESCRIPTION
reuse compute_name variable instead of freetext

# Description

compute_name variable has the same value needed for the compute name..

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
