### PR TITLE
pin simplification package version to avoid numpy version update

### DIFF
--- a/cli/jobs/automl-standalone-jobs/cli-automl-image-instance-segmentation-task-fridge-items/prepare_data.py
+++ b/cli/jobs/automl-standalone-jobs/cli-automl-image-instance-segmentation-task-fridge-items/prepare_data.py
@@ -83,7 +83,7 @@ def upload_data_and_create_jsonl_mltable_files(ml_client, dataset_parent_dir):
     )
     # Install numpy version compatible with scikit-image==0.19.3.
     subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "simplification"])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "simplification==0.7.12"])
     print("done")
 
     print("Creating jsonl files")

--- a/cli/jobs/automl-standalone-jobs/cli-automl-image-instance-segmentation-task-fridge-items/prepare_data.py
+++ b/cli/jobs/automl-standalone-jobs/cli-automl-image-instance-segmentation-task-fridge-items/prepare_data.py
@@ -83,7 +83,9 @@ def upload_data_and_create_jsonl_mltable_files(ml_client, dataset_parent_dir):
     )
     # Install numpy version compatible with scikit-image==0.19.3.
     subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "simplification==0.7.12"])
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "simplification==0.7.12"]
+    )
     print("done")
 
     print("Creating jsonl files")

--- a/cli/jobs/pipelines/automl/image-instance-segmentation-task-fridge-items-pipeline/prepare_data.py
+++ b/cli/jobs/pipelines/automl/image-instance-segmentation-task-fridge-items-pipeline/prepare_data.py
@@ -83,7 +83,7 @@ def upload_data_and_create_jsonl_mltable_files(ml_client, dataset_parent_dir):
     )
     # Install numpy version compatible with scikit-image==0.19.3.
     subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "simplification"])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "simplification==0.7.12"])
     print("done")
 
     print("Creating jsonl files")

--- a/cli/jobs/pipelines/automl/image-instance-segmentation-task-fridge-items-pipeline/prepare_data.py
+++ b/cli/jobs/pipelines/automl/image-instance-segmentation-task-fridge-items-pipeline/prepare_data.py
@@ -83,7 +83,9 @@ def upload_data_and_create_jsonl_mltable_files(ml_client, dataset_parent_dir):
     )
     # Install numpy version compatible with scikit-image==0.19.3.
     subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.26.4"])
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "simplification==0.7.12"])
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "simplification==0.7.12"]
+    )
     print("done")
 
     print("Creating jsonl files")

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-instance-segmentation-task-fridge-items/automl-image-instance-segmentation-task-fridge-items.ipynb
@@ -255,7 +255,7 @@
    "outputs": [],
    "source": [
     "!pip install pycocotools\n",
-    "!pip install simplification\n",
+    "!pip install simplification==0.7.12\n",
     "!pip install scikit-image"
    ]
   },

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
@@ -242,7 +242,7 @@
    "outputs": [],
    "source": [
     "!pip install pycocotools\n",
-    "!pip install simplification\n",
+    "!pip install simplification==0.7.12\n",
     "!pip install scikit-image"
    ]
   },


### PR DESCRIPTION
# Description
Pin simplification package to version 0.7.12 because version 0.7.13 requires numpy>2.0.0 while our notebooks have a dependency on numpy==1.26.4

cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items
cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items-automode
cli-jobs-pipelines-automl-image-instance-segmentation-task-fridge-items-pipeline-pipeline
sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model
sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
