### PR TITLE
pin simplification package version

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -259,7 +259,7 @@
    "outputs": [],
    "source": [
     "!pip install pycocotools\n",
-    "!pip install simplification\n",
+    "!pip install simplification==0.7.12\n",
     "!pip install scikit-image"
    ]
   },


### PR DESCRIPTION
# Description
Pin simplification package to version 0.7.12 because version 0.7.13 requires numpy>2.0.0 while our notebooks have a dependency on numpy==1.26.4

sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
