### PR TITLE
Fix protobuf IndentationError issue

### DIFF
--- a/sdk/python/setup.sh
+++ b/sdk/python/setup.sh
@@ -20,4 +20,7 @@ pip install azure-ai-ml
 # https://docsupport.blob.core.windows.net/ml-sample-submissions/1905732/azure_ai_ml-1.0.0-py3-none-any.whl
 # </az_ml_sdk_test_install>
 
+# protobuf==5.29.0 has IndentationError bug
+pip install protobuf<=5.28.3
+
 pip list

--- a/sdk/python/setup.sh
+++ b/sdk/python/setup.sh
@@ -21,6 +21,6 @@ pip install azure-ai-ml
 # </az_ml_sdk_test_install>
 
 # protobuf==5.29.0 has IndentationError bug
-pip install protobuf<=5.28.3
+pip install "protobuf<=5.28.3"
 
 pip list


### PR DESCRIPTION
# Description
AutoML notebooks are failing because the latest version of protobuf leads to IdentationError. The solution is to pin this package so that the latest version is not pulled.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
