### PR TITLE
Pin protobuf version

### DIFF
--- a/sdk/python/dev-requirements.txt
+++ b/sdk/python/dev-requirements.txt
@@ -11,3 +11,4 @@ tensorflow-hub==0.15.0
 transformers==4.34.0
 keras==2.9
 jupyter-client==7.4.9
+protobuf==3.20.1


### PR DESCRIPTION
# Description

Multiple batch endpoint SDK notebooks fail due to an incompatible version of the protobuf package. The solution is to pin the package to an older version. https://github.com/protocolbuffers/protobuf/issues/10051#issuecomment-1138392640

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
