### PR TITLE
Bump transformers version and remove protobuf version

### DIFF
--- a/sdk/python/dev-requirements.txt
+++ b/sdk/python/dev-requirements.txt
@@ -8,7 +8,6 @@ matplotlib==3.7.3
 torch==2.1.0
 tensorflow==2.9.3
 tensorflow-hub==0.15.0
-transformers==4.34.0
+transformers==4.46.3
 keras==2.9
 jupyter-client==7.4.9
-protobuf==3.20.1


### PR DESCRIPTION
# Description
PR #3452 caused a version conflict. So instead of pinning protobuf, let's bump the transformers version.

```
ERROR: Cannot install -r sdk/python/dev-requirements.txt (line 9) and protobuf==3.20.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested protobuf==3.20.1
    tensorflow 2.9.3 depends on protobuf<3.20 and >=3.9.2

```
# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
