### PR TITLE
Revert pinned version for protobuf

### DIFF
--- a/sdk/python/dev-requirements.txt
+++ b/sdk/python/dev-requirements.txt
@@ -11,4 +11,3 @@ tensorflow-hub==0.15.0
 transformers==4.34.0
 keras==2.9
 jupyter-client==7.4.9
-protobuf==3.20.1


### PR DESCRIPTION
# Description
Reverts PR https://github.com/Azure/azureml-examples/pull/3452 which caused a version conflict.

```
ERROR: Cannot install -r sdk/python/dev-requirements.txt (line 9) and protobuf==3.20.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested protobuf==3.20.1
    tensorflow 2.9.3 depends on protobuf<3.20 and >=3.9.2
```

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
