### PR TITLE
Update OpenAI embeddings notebook

### DIFF
--- a/sdk/python/endpoints/batch/deploy-models/openai-embeddings/deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/openai-embeddings/deploy-and-test.ipynb
@@ -511,7 +511,7 @@
    },
    "outputs": [],
    "source": [
-    "endpoint = ml_client.batch_endpoints.get(endpoint.name)\n",
+    "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
     "endpoint.defaults.deployment_name = deployment.name\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
@@ -758,9 +758,21 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "from io import StringIO\n",
     "\n",
-    "embeddings = pd.read_json(\"named-outputs/score/embeddings.jsonl\", lines=True)\n",
-    "embeddings"
+    "# Read the output data into an object.\n",
+    "with open(\"embeddings.jsonl\", \"r\") as f:\n",
+    "json_lines = f.readlines()\n",
+    "string_io = StringIO()\n",
+    "for line in json_lines:\n",
+    "string_io.write(line)\n",
+    "string_io.seek(0)\n",
+    "\n",
+    "# Read the data into a data frame.\n",
+    "embeddings = pd.read_json(string_io, lines=True)\n",
+    "\n",
+    "# Print the data frame.\n",
+    "print(embeddings)"
    ]
   },
   {
@@ -784,7 +796,7 @@
    ]
   }
  ],
- "metadata": { },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
# Description

This PR makes the following changes to [Score OpenAI models in batch using Batch Endpoints](https://github.com/Azure/azureml-examples/blob/main/sdk/python/endpoints/batch/deploy-models/openai-embeddings/deploy-and-test.ipynb):

- On line 514, the parameter `endpoint.name` is replaced with `endpoint_name`. The purpose of that line is to get the endpoint from the name, which is stored in the `endpoint_name` variable. The endpoint itself isn't yet available, so it can't be used in code like `endpoint.name`.
- On line 761, the original code generates the following warning: *FutureWarning: Passing literal json to 'read_json' is deprecated and will be removed in a future version. To read from a literal string, wrap it in a 'StringIO' object.* To eliminate that warning, this PR updates that code so it uses a `StringIO` object instead of a literal file name.

The following attached files can be used to test the changes to the code around line 761: 

- [test-code-update.txt](https://github.com/user-attachments/files/18186044/test-code-update.txt): Save it as *test-code-update.py* to run the test script.
- [embeddings.json](https://github.com/user-attachments/files/18186062/embeddings.json): Save it as *embeddings.jsonl* to use as input for the test script.

# Checklist

- [X] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [X] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [X] Pull request includes test coverage for the included changes.
- [X] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
