### PR TITLE
Pin pandas version to fix numpy incompatibility issue

### DIFF
--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items-batch-scoring/image-object-detection-batch-scoring-non-mlflow-model.ipynb
@@ -243,7 +243,8 @@
    "source": [
     "!pip install pycocotools\n",
     "!pip install simplification==0.7.12\n",
-    "!pip install scikit-image"
+    "!pip install scikit-image\n",
+    "!pip install pandas==2.2.1"
    ]
   },
   {

--- a/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
+++ b/sdk/python/jobs/automl-standalone-jobs/automl-image-object-detection-task-fridge-items/automl-image-object-detection-task-fridge-items.ipynb
@@ -260,7 +260,8 @@
    "source": [
     "!pip install pycocotools\n",
     "!pip install simplification==0.7.12\n",
-    "!pip install scikit-image"
+    "!pip install scikit-image\n",
+    "!pip install pandas==2.2.1"
    ]
   },
   {


### PR DESCRIPTION
# Description

Error: `ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject` \
Fix: First answer, second comment https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
