### PR TITLE
Fix RAI multilabel classification notebook failure by pinning

### DIFF
--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-image-classification-fridge.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-image-classification-fridge.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"21\""
+    "rai_example_version_string = \"24\""
    ]
   },
   {
@@ -441,7 +441,8 @@
     "    mlflow.fastai.log_model(\n",
     "        model,\n",
     "        artifact_path=registered_name,\n",
-    "        registered_model_name=registered_name\n",
+    "        registered_model_name=registered_name,\n",
+    "        pip_requirements=['shap==0.43.0']\n",
     "    )\n",
     "\n",
     "    _logger.info(\"Writing JSON\")\n",
@@ -579,7 +580,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"fridge_model\"\n",
-    "model_name_suffix = \"12492\"\n",
+    "model_name_suffix = \"12495\"\n",
     "device = -1"
    ]
   },

--- a/sdk/python/responsible-ai/vision/responsibleaidashboard-image-multilabel-classification-fridge.ipynb
+++ b/sdk/python/responsible-ai/vision/responsibleaidashboard-image-multilabel-classification-fridge.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rai_example_version_string = \"22\""
+    "rai_example_version_string = \"28\""
    ]
   },
   {
@@ -445,7 +445,8 @@
     "    mlflow.fastai.log_model(\n",
     "        model,\n",
     "        artifact_path=registered_name,\n",
-    "        registered_model_name=registered_name\n",
+    "        registered_model_name=registered_name,\n",
+    "        pip_requirements=['shap==0.43.0']\n",
     "    )\n",
     "\n",
     "    _logger.info(\"Writing JSON\")\n",
@@ -583,7 +584,7 @@
     "import time\n",
     "\n",
     "model_base_name = \"multilabel_fridge_model\"\n",
-    "model_name_suffix = \"12492\"\n",
+    "model_name_suffix = \"12495\"\n",
     "device = -1"
    ]
   },


### PR DESCRIPTION
# Description

Fix RAI multilabel classification notebook failure by pinning
Pinned shap==0.42.0 on mlflow model to resolve error in "RAI Vision Insights" component.
Originally tried to pin numpy<1.24.0, but it didn't work - seems use_conda is not working right now. However, I was still able to make it work by instead upgrading shap.
See commit in shap 0.42.0 that fixes this:
https://github.com/shap/shap/commit/231cbdc35ef3dc5050cd63cd7ddeb4f0becfd78f

Error message:
```
Traceback (most recent call last):
  File "/mnt/azureml/cr/j/a896ff0f5fcc40aca1ad9f27d606f315/exe/wd/./rai_vision_insights.py", line 540, in <module>
    main(args)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/azureml/rai/utils/telemetry/loggerfactory.py", line 153, in wrapper
    return func(*args, **kwargs)
  File "/mnt/azureml/cr/j/a896ff0f5fcc40aca1ad9f27d606f315/exe/wd/./rai_vision_insights.py", line 507, in main
    rai_vi.compute(**automl_xai_args)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/responsibleai_vision/rai_vision_insights/rai_vision_insights.py", line 303, in compute
    manager.compute(**kwargs)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/responsibleai_vision/managers/explainer_manager.py", line 180, in compute
    self.compute_single_explanation(i, **kwargs)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/responsibleai_vision/managers/explainer_manager.py", line 245, in compute_single_explanation
    explanation = self.get_shap_explanations(image, max_evals)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/responsibleai_vision/managers/explainer_manager.py", line 328, in get_shap_explanations
    explainer = shap.Explainer(self._model.predict_proba,
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/shap/explainers/_explainer.py", line 184, in __init__
    explainers.Partition.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, output_names=self.output_names, **kwargs)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/shap/explainers/_partition.py", line 113, in __init__
    self._mask_matrix = make_masks(self._clustering)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/shap/utils/_masked_model.py", line 413, in make_masks
    indices_row_pos = np.zeros(2 * M - 1, dtype=np.int)
  File "/azureml-envs/responsibleai-vision/lib/python3.9/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
