### PR TITLE
Fix link to Python SDK v2

### DIFF
--- a/sdk/python/endpoints/online/custom-container/online-endpoints-custom-container.ipynb
+++ b/sdk/python/endpoints/online/custom-container/online-endpoints-custom-container.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "* To use Azure Machine Learning, you must have an Azure subscription. If you don't have an Azure subscription, create a free account before you begin. Try the [free or paid version of Azure Machine Learning](https://azure.microsoft.com/free/).\n",
     "\n",
-    "* Install and configure the [Python SDK v2](sdk/setup.sh).\n",
+    "* Install and configure the [Python SDK v2](https://learn.microsoft.com/en-us/python/api/overview/azure/ai-ml-readme?view=azure-python).\n",
     "\n",
     "* You must have an Azure resource group, and you (or the service principal you use) must have Contributor access to it.\n",
     "\n",


### PR DESCRIPTION
# Description
The notebook has been updated to fix the link to the Python SDK v2 installation instructions.

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
