### PR TITLE
Ignore warnings for Notebook test runs

### DIFF
--- a/.github/test/scripts/check_notebook_output.py
+++ b/.github/test/scripts/check_notebook_output.py
@@ -84,7 +84,7 @@ allowed_list = [
     "from google.protobuf import service as _service",
     "UserWarning: This class is intended as a base class and it's direct usage is deprecated",
     "warnings.warn",
-    "UserWarning: pkg_resources is deprecated as an API."
+    "UserWarning: pkg_resources is deprecated as an API.",
 ]
 
 with open(full_name, "r") as notebook_file:

--- a/.github/test/scripts/check_notebook_output.py
+++ b/.github/test/scripts/check_notebook_output.py
@@ -82,6 +82,9 @@ allowed_list = [
         "which generate code specific to the RPC implementation. service.py will be removed in Jan 2025"
     ),
     "from google.protobuf import service as _service",
+    "UserWarning: This class is intended as a base class and it's direct usage is deprecated",
+    "warnings.warn",
+    "UserWarning: pkg_resources is deprecated as an API."
 ]
 
 with open(full_name, "r") as notebook_file:


### PR DESCRIPTION
# Description
Few of the notebook test jobs are failing at "check notebook output" step as notebook code cell output throws warnings.
Ignoring the warnings to get the runs succeeded.

Below are the warning thrown:

/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/site-packages/azureml/dataprep/api/_loggerfactory.py:8: UserWarning: pkg_resources is deprecated as an API. See [https://setuptools.pypa.io/en/latest/pkg_resources.html.](https://setuptools.pypa.io/en/latest/pkg_resources.html) The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81


opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/site-packages/azure/ai/ml/entities/_deployment/batch_deployment.py:137: UserWarning: This class is intended as a base class and it's direct usage is deprecated. Use one of the concrete implementations instead:
* ModelBatchDeployment - For model-based batch deployments
* PipelineComponentBatchDeployment - For pipeline component-based batch deployments
  warnings. Warn(

[sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau](https://github.com/Azure/azureml-examples/actions/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml?query=event%3Aschedule)

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
