### PR TITLE
[Fix]: Add accuracy also and reword informative assertions

### DIFF
--- a/sdk/python/jobs/grpo/aml_setup.py
+++ b/sdk/python/jobs/grpo/aml_setup.py
@@ -75,7 +75,7 @@ def setup_model():
     # Download model from Hugging Face and register in Azure ML workspace
     try:
         model = ml_client.models.get(name=model_name, label="latest")
-        print(f"✅ Model {model_name} created in AML workspace.")
+        print(f"✅ Selected model {model_name} from AML workspace.")
     except ResourceNotFoundError:
         print(f"❌ Model {model_name} not found, downloading and registering...")
         from huggingface_hub import snapshot_download
@@ -107,7 +107,7 @@ def setup_compute():
     try:
         # Try to get the existing compute cluster
         compute = ml_client.compute.get(compute_cluster)
-        print(f"✅ Compute cluster {compute_cluster} created in AML workspace.")
+        print(f"✅ Selected compute cluster {compute_cluster} from AML workspace.")
     except Exception:
         print(
             f"❌ Compute cluster '{compute_cluster}' not found. Creating a new one ({compute_cluster_size})..."
@@ -149,7 +149,7 @@ def setup_environment():
     try:
         # Try to get the existing environment from Azure ML workspace
         environment = ml_client.environments.get(name=env_name, label="latest")
-        print(f"✅ Environment {env_name} created in AML workspace.")
+        print(f"✅ Selected environment {env_name} from AML workspace.")
     except ResourceNotFoundError as e:
         # If not found, create a new environment using the specified build context
         print(f"❌ Environment {env_name} not found, creating a new one.")

--- a/sdk/python/jobs/grpo/src/BldDemo_Reasoning_Train.py
+++ b/sdk/python/jobs/grpo/src/BldDemo_Reasoning_Train.py
@@ -51,7 +51,7 @@ class GRPOScriptArguments(ScriptArguments):
         default="final_model", metadata={"help": "Path to save the final model."}
     )
     reward_funcs: list[str] = field(
-        default_factory=lambda: ["format","accuracy"],
+        default_factory=lambda: ["format", "accuracy"],
         metadata={
             "help": "List of reward functions. Possible values: 'format', 'accuracy'."
         },

--- a/sdk/python/jobs/grpo/src/BldDemo_Reasoning_Train.py
+++ b/sdk/python/jobs/grpo/src/BldDemo_Reasoning_Train.py
@@ -51,7 +51,7 @@ class GRPOScriptArguments(ScriptArguments):
         default="final_model", metadata={"help": "Path to save the final model."}
     )
     reward_funcs: list[str] = field(
-        default_factory=lambda: ["format"],
+        default_factory=lambda: ["format","accuracy"],
         metadata={
             "help": "List of reward functions. Possible values: 'format', 'accuracy'."
         },


### PR DESCRIPTION
# Description
- By default we'll need to utilize accuracy rewards as well. Since we tested methodology for accuracy improvement.
- .get() method just selects the workspace resource rather than creation. Made appropriate changes to the print statements to reflect this.
- link to test run <a href="https://ml.azure.com/experiments/id/e7aac186-5b02-4fb6-bf26-0a7ca50e8540/runs/quirky_leaf_zgrr64z52r?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/validatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#overview" target="_blank"> click here </a>
# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
