### PR TITLE
Remove failing workflow (import model from HF) workflow from running schedule

### DIFF
--- a/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry_new_model_image_tasks.yml
+++ b/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry_new_model_image_tasks.yml
@@ -10,7 +10,6 @@ on:
       - main
     paths:
       - sdk/python/foundation-models/system/import/**
-      - .github/workflows/sdk-foundation-models-system-import-import_model_into_registry_new_model_image_tasks.yml
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh


### PR DESCRIPTION
Removed workflow file from paths to trigger on main branch - This workflow has been failing for several months now. 

# Description

Remove import model from HF notebook from running on schedule

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
