### PR TITLE
Add trigger for azureml-mlflow related workflows

### DIFF
--- a/.github/workflows/sdk-endpoints-batch-deploy-models-heart-classifier-mlflow-mlflow-for-batch-tabular.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-heart-classifier-mlflow-mlflow-for-batch-tabular.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-huggingface-text-summarization-text-summarization-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-huggingface-text-summarization-text-summarization-batch.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-mlflow.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-mlflow.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-distributed-tcn-automl-forecasting-distributed-tcn.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-distributed-tcn-automl-forecasting-distributed-tcn.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-run.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-run.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-responsible-ai-mlflow-deployment-with-explanations-mlflow-deployment-with-explanations.yml
+++ b/.github/workflows/sdk-responsible-ai-mlflow-deployment-with-explanations-mlflow-deployment-with-explanations.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-finance-loan-classification-responsibleaidashboard-finance-loan-classification.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-finance-loan-classification-responsibleaidashboard-finance-loan-classification.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-healthcare-covid-classification-responsibleaidashboard-healthcare-covid-classification.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-healthcare-covid-classification-responsibleaidashboard-healthcare-covid-classification.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 
 permissions:
   id-token: write

--- a/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
+++ b/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
+++ b/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
+++ b/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
+++ b/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:

--- a/.github/workflows/tutorials-get-started-notebooks-train-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-train-model.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - sdk/python/mlflow-requirements.txt
 permissions:
   id-token: write
 concurrency:


### PR DESCRIPTION
# Description
If we want to run the samples/workflows on our wheel of azureml-mlflow for testing purpose, by updating here: https://github.com/Azure/azureml-examples/blob/main/sdk/python/mlflow-requirements.txt

Then respective workflows which install azureml-mlflow from the above file don't get trigger automatically. So added a trigger for the same.

# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
