### PR TITLE
fix(batch-pipelines): pin mlflow version for azureml-mlflow compatibi…

### DIFF
--- a/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/environment/conda.yml
+++ b/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/environment/conda.yml
@@ -1,10 +1,10 @@
 channels:
 - conda-forge
 dependencies:
-- python=3.8.5
+- python=3.10
 - pip
 - pip:
-  - mlflow
+  - mlflow<3
   - azureml-mlflow
   - datasets
   - jobtools
@@ -12,4 +12,5 @@ dependencies:
   - dask==2.30.0
   - scikit-learn==1.1.2
   - xgboost==1.3.3
+  - numpy<2
 name: mlflow-env

--- a/sdk/python/endpoints/batch/deploy-pipelines/training-with-components/environment/conda.yml
+++ b/sdk/python/endpoints/batch/deploy-pipelines/training-with-components/environment/conda.yml
@@ -1,10 +1,10 @@
 channels:
 - conda-forge
 dependencies:
-- python=3.8.5
+- python=3.10
 - pip
 - pip:
-  - mlflow
+  - mlflow<3
   - azureml-mlflow
   - datasets
   - jobtools
@@ -13,4 +13,5 @@ dependencies:
   - scikit-learn==1.1.2
   - xgboost==1.3.3
   - pandas==1.4
+  - numpy<2
 name: mlflow-env


### PR DESCRIPTION
…lity

Pin mlflow==2.8.1 to ensure the azureml-mlflow plugin correctly registers the azureml:// URI scheme on Python 3.8.5. The unpinned mlflow resolved to an incompatible version, causing UnsupportedModelRegistryStoreURIException in prepare.py.

Also fix jobtools -> joblib typo in both conda.yml files.

# Description


# Checklist


- [x] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] Pull request includes test coverage for the included changes.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
