### PR TITLE
fix: add PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python to resolve pro…

### DIFF
--- a/cli/jobs/pipelines/tensorflow-image-segmentation/pipeline.yml
+++ b/cli/jobs/pipelines/tensorflow-image-segmentation/pipeline.yml
@@ -52,6 +52,8 @@ jobs:
 
     # NOTE: set env var if needed
     environment_variables:
+      # force pure-python protobuf to avoid _upb FieldDescriptor.label bug with MLflow
+      PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: "python"
       # adjusts the level of info from NCCL tests
       NCCL_DEBUG: "INFO"
       NCCL_DEBUG_SUBSYS: "GRAPH,INIT,ENV"


### PR DESCRIPTION
…tobuf 5.x/MLflow incompatibility

The curated tensorflow-2.16-cuda12 environment was updated with protobuf 5.x, which uses _upb C implementation that drops FieldDescriptor.label attribute. This causes MLflow log_batch() to crash with AttributeError.

Setting PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python forces the compatible pure Python implementation.

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
