### PR TITLE
Pin minimal-py312-inference image to 20260316.v1 to fix deployment crash

### DIFF
--- a/sdk/python/endpoints/online/managed/online-endpoints-keyvault.ipynb
+++ b/sdk/python/endpoints/online/managed/online-endpoints-keyvault.ipynb
@@ -338,7 +338,7 @@
     "    ),\n",
     "    environment=Environment(\n",
     "        conda_file=\"keyvault/env.yml\",\n",
-    "        image=\"mcr.microsoft.com/azureml/minimal-py312-inference\",\n",
+    "        image=\"mcr.microsoft.com/azureml/minimal-py312-inference:20260316.v1\",\n",
     "    ),\n",
     "    environment_variables={\n",
     "        \"KV_SECRET_MULTIPLIER\": f\"multiplier@https://{keyvault_name}.vault.azure.net\"\n",


### PR DESCRIPTION
The latest image tag (20260401.v1) causes the conda environment setup to fail, resulting in a container crash and liveness probe failure. Pin to the last known working tag until the issue is resolved upstream.

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
