### PR TITLE
Remove unused azure-ai-ml and fix azure-keyvault dep in keyvault env.yml

### DIFF
--- a/sdk/python/endpoints/online/managed/keyvault/env.yml
+++ b/sdk/python/endpoints/online/managed/keyvault/env.yml
@@ -5,5 +5,4 @@ dependencies:
   - pip:
     - azureml-inference-server-http
     - azure-identity
-    - azure-ai-ml
-    - azure-keyvault
+    - azure-keyvault-secrets


### PR DESCRIPTION
- Remove azure-ai-ml: not imported in score.py, adds 20+ transitive deps causing pip resolution failure with updated base image
- Replace deprecated azure-keyvault with azure-keyvault-secrets: score.py imports from azure.keyvault.secrets, not the meta-package

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
