### PR TITLE
Fix densenet pipeline: update EOL Docker images and DALI CUDA version

### DIFF
--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/apply_image_transformation/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/apply_image_transformation/entry.spec.yaml
@@ -32,4 +32,4 @@ command: >-
   --output-path ${{outputs.output_path}}
 environment:
   conda_file: ./conda.yaml
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest
+  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:latest

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/convert_to_image_directory/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/convert_to_image_directory/entry.spec.yaml
@@ -22,4 +22,4 @@ command: >-
   --output-path ${{outputs.output_path}}
 environment:
   conda_file: ./conda.yaml
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest
+  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:latest

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/conda.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/conda.yaml
@@ -3,19 +3,19 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.8.12
-  - pip=21.2.2
+  - python=3.10
+  - pip=23.3
   - pip:
       - mldesigner==0.1.0b4
-      - watchdog==0.10.3
-      - torch==1.8.1
-      - torchvision==0.9.1
-      - tensorboard==2.5.0
-      - pillow==8.2.0
-      - numpy==1.19.5
+      - watchdog==4.0.1
+      - torch==2.4.0
+      - torchvision==0.19.0
+      - tensorboard==2.17.0
+      - pillow==10.4.0
+      - numpy==1.26.4
       - --extra-index-url=https://developer.download.nvidia.com/compute/redist/
-      - nvidia-dali-cuda100
+      - nvidia-dali-cuda120
       - azureml-mlflow>=1.41.0
-      - protobuf==3.20.1
-      - pandas==1.2.1
+      - protobuf==4.25.3
+      - pandas==2.2.2
       - packaging==22.0 # fix for https://github.com/pypa/setuptools/issues/4483

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/conda.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/conda.yaml
@@ -14,7 +14,7 @@ dependencies:
       - pillow==8.2.0
       - numpy==1.19.5
       - --extra-index-url=https://developer.download.nvidia.com/compute/redist/
-      - nvidia-dali-cuda100
+      - nvidia-dali-cuda110
       - azureml-mlflow>=1.41.0
       - protobuf==3.20.1
       - pandas==1.2.1

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/image_cnn_train/entry.spec.yaml
@@ -111,7 +111,7 @@ outputs:
 code: ./
 
 environment:
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest
+  image: mcr.microsoft.com/azureml/openmpi5.0-cuda12.4-ubuntu22.04:latest
   conda_file: ./conda.yaml
 
 resources:
@@ -121,8 +121,8 @@ distribution:
   process_count_per_instance: 1
 
 command: >-
-  git clone https://github.com/NVIDIA/apex && cd apex && git checkout 3303b3e7174383312a3468ef390060c26e640cb1 
-  && python setup.py install && cd ..  
+  pip install ninja && git clone https://github.com/NVIDIA/apex && cd apex
+  && pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" . && cd ..  
   && mldesigner execute --source entry.py --name imagecnn_train --inputs train_data=${{inputs.train_data}} 
   val_data=${{inputs.valid_data}} data_backend=${{inputs.data_backend}} arch=${{inputs.arch}} 
   model_config=${{inputs.model_config}} workers=${{inputs.workers}} epochs=${{inputs.epochs}} 

--- a/cli/jobs/pipelines-with-components/image_classification_with_densenet/init_image_transformation/entry.spec.yaml
+++ b/cli/jobs/pipelines-with-components/image_classification_with_densenet/init_image_transformation/entry.spec.yaml
@@ -124,4 +124,4 @@ command: >-
   
 environment:
   conda_file: ./conda.yaml
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest
+  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:latest

--- a/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/conda.yaml
+++ b/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/conda.yaml
@@ -14,7 +14,7 @@ dependencies:
       - pillow==8.2.0
       - numpy==1.19.5
       - --extra-index-url=https://developer.download.nvidia.com/compute/redist/
-      - nvidia-dali-cuda100
+      - nvidia-dali-cuda110
       - azureml-mlflow>=1.41.0
       - protobuf==3.20.1
       - pandas==1.2.1

--- a/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/conda.yaml
+++ b/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/conda.yaml
@@ -3,19 +3,19 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.8.12
-  - pip=21.2.2
+  - python=3.10
+  - pip=23.3
   - pip:
       - mldesigner==0.1.0b4
-      - watchdog==0.10.3
-      - torch==1.8.1
-      - torchvision==0.9.1
-      - tensorboard==2.5.0
-      - pillow==8.2.0
-      - numpy==1.19.5
+      - watchdog==4.0.1
+      - torch==2.4.0
+      - torchvision==0.19.0
+      - tensorboard==2.17.0
+      - pillow==10.4.0
+      - numpy==1.26.4
       - --extra-index-url=https://developer.download.nvidia.com/compute/redist/
-      - nvidia-dali-cuda100
+      - nvidia-dali-cuda120
       - azureml-mlflow>=1.41.0
-      - protobuf==3.20.1
-      - pandas==1.2.1
+      - protobuf==4.25.3
+      - pandas==2.2.2
       - packaging>=22.0 # fix for https://github.com/pypa/setuptools/issues/4483

--- a/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/entry.spec.yaml
+++ b/sdk/python/jobs/pipelines/2d_image_classification_with_densenet/imagecnn_train/entry.spec.yaml
@@ -111,7 +111,7 @@ outputs:
 code: ./
 
 environment:
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04
+  image: mcr.microsoft.com/azureml/openmpi5.0-cuda12.4-ubuntu22.04:latest
   conda_file: ./conda.yaml
 
 resources:
@@ -121,8 +121,8 @@ distribution:
   process_count_per_instance: 1
 
 command: >-
-  git clone https://github.com/NVIDIA/apex && cd apex && git checkout 3303b3e7174383312a3468ef390060c26e640cb1 
-  && python setup.py install && cd ..  
+  pip install ninja && git clone https://github.com/NVIDIA/apex && cd apex
+  && pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" . && cd ..  
   && mldesigner execute --source entry.py --name imagecnn_train --inputs train_data=${{inputs.train_data}} 
   val_data=${{inputs.valid_data}} data_backend=${{inputs.data_backend}} arch=${{inputs.arch}} 
   model_config=${{inputs.model_config}} workers=${{inputs.workers}} epochs=${{inputs.epochs}} 


### PR DESCRIPTION
- Update ubuntu20.04 base images to ubuntu22.04 (convert_to_image_directory, apply_image_transformation)
- Remove unnecessary CUDA image from init_image_transformation (CPU-only step, aligned with SDK)
- Fix nvidia-dali-cuda100 -> nvidia-dali-cuda110 to match CUDA 11.8 base image (CLI + SDK)

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
