### PR TITLE
Pin sklearn-1.5 environment to version 35 in 1c_pipeline_with_hyperpa…

### DIFF
--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb
@@ -129,7 +129,6 @@
    "outputs": [],
    "source": [
     "train_component_func = load_component(source=\"./train.yml\")\n",
-    "score_component_func = load_component(source=\"./predict.yml\")\n",
     "\n",
     "# define a pipeline\n",
     "@pipeline()\n",
@@ -162,10 +161,6 @@
     "        compute=\"cpu-cluster\",\n",
     "    )\n",
     "    sweep_step.set_limits(max_total_trials=20, max_concurrent_trials=10, timeout=7200)\n",
-    "\n",
-    "    score_data = score_component_func(\n",
-    "        model=sweep_step.outputs.model_output, test_data=sweep_step.outputs.test_data\n",
-    "    )\n",
     "\n",
     "\n",
     "pipeline_job = pipeline_with_hyperparameter_sweep()\n",

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb
@@ -129,6 +129,7 @@
    "outputs": [],
    "source": [
     "train_component_func = load_component(source=\"./train.yml\")\n",
+    "score_component_func = load_component(source=\"./predict.yml\")\n",
     "\n",
     "# define a pipeline\n",
     "@pipeline()\n",
@@ -161,6 +162,10 @@
     "        compute=\"cpu-cluster\",\n",
     "    )\n",
     "    sweep_step.set_limits(max_total_trials=20, max_concurrent_trials=10, timeout=7200)\n",
+    "\n",
+    "    score_data = score_component_func(\n",
+    "        model=sweep_step.outputs.model_output, test_data=sweep_step.outputs.test_data\n",
+    "    )\n",
     "\n",
     "\n",
     "pipeline_job = pipeline_with_hyperparameter_sweep()\n",

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
@@ -13,10 +13,10 @@ outputs:
   predict_result:
     type: uri_folder
 code: ./predict-src
-environment: azureml://registries/azureml/environments/sklearn-1.5/versions/42
+environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
 command: >-
   python predict.py 
-  --model '${{inputs.model}}' 
-  --test_data '${{inputs.test_data}}' 
-  --predict_result '${{outputs.predict_result}}'
+  --model ${{inputs.model}} 
+  --test_data ${{inputs.test_data}} 
+  --predict_result ${{outputs.predict_result}}
 # </component>

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
@@ -13,7 +13,7 @@ outputs:
   predict_result:
     type: uri_folder
 code: ./predict-src
-environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
+environment: azureml://registries/azureml/environments/sklearn-1.5/versions/35
 command: >-
   python predict.py 
   --model ${{inputs.model}} 

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
@@ -13,7 +13,7 @@ outputs:
   predict_result:
     type: uri_folder
 code: ./predict-src
-environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
+environment: azureml://registries/azureml/environments/sklearn-1.5/versions/42
 command: >-
   python predict.py 
   --model ${{inputs.model}} 

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
@@ -6,14 +6,14 @@ version: 1
 type: command
 inputs:
   model: 
-    type: mlflow_model
+    type: uri_folder
   test_data:
     type: uri_folder
 outputs:
   predict_result:
     type: uri_folder
 code: ./predict-src
-environment: azureml://registries/azureml/environments/sklearn-1.5/versions/42
+environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
 command: >-
   python predict.py 
   --model ${{inputs.model}} 

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
@@ -6,17 +6,17 @@ version: 1
 type: command
 inputs:
   model: 
-    type: uri_folder
+    type: mlflow_model
   test_data:
     type: uri_folder
 outputs:
   predict_result:
     type: uri_folder
 code: ./predict-src
-environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
+environment: azureml://registries/azureml/environments/sklearn-1.5/versions/42
 command: >-
   python predict.py 
-  --model ${{inputs.model}} 
-  --test_data ${{inputs.test_data}} 
-  --predict_result ${{outputs.predict_result}}
+  --model '${{inputs.model}}' 
+  --test_data '${{inputs.test_data}}' 
+  --predict_result '${{outputs.predict_result}}'
 # </component>

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
@@ -59,7 +59,7 @@ outputs:
   
 code: ./train-src
 
-environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
+environment: azureml://registries/azureml/environments/sklearn-1.5/versions/42
 
 command: >-
   python train.py 

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
@@ -53,13 +53,13 @@ inputs:
 
 outputs:
   model_output:
-    type: uri_folder
+    type: mlflow_model
   test_data:
     type: uri_folder
   
 code: ./train-src
 
-environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
+environment: azureml://registries/azureml/environments/sklearn-1.5/versions/42
 
 command: >-
   python train.py 

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
@@ -59,7 +59,7 @@ outputs:
   
 code: ./train-src
 
-environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
+environment: azureml://registries/azureml/environments/sklearn-1.5/versions/35
 
 command: >-
   python train.py 

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
@@ -53,13 +53,13 @@ inputs:
 
 outputs:
   model_output:
-    type: mlflow_model
+    type: uri_folder
   test_data:
     type: uri_folder
   
 code: ./train-src
 
-environment: azureml://registries/azureml/environments/sklearn-1.5/versions/42
+environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
 
 command: >-
   python train.py 


### PR DESCRIPTION
…rameter_sweep

The floating labels/latest reference broke the /score_data pipeline step after a new environment version was published around Dec 16. Pin to version 35 (Nov 25, 2025) which was the last known stable version.

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
