### PR TITLE
Fix MLflow compatibility in pipeline tutorial train.py

### DIFF
--- a/tutorials/get-started-notebooks/pipeline.ipynb
+++ b/tutorials/get-started-notebooks/pipeline.ipynb
@@ -677,7 +677,7 @@
     "  # for this step, we'll use an AzureML curate environment\n",
     "  azureml://registries/azureml/environments/sklearn-1.5/labels/latest\n",
     "command: >-\n",
-    "  python train.py \n",
+    "  pip install 'mlflow<2.19' -q && python train.py \n",
     "  --train_data ${{inputs.train_data}} \n",
     "  --test_data ${{inputs.test_data}} \n",
     "  --learning_rate ${{inputs.learning_rate}}\n",


### PR DESCRIPTION
The curated sklearn-1.5 environment updated MLflow to 2.19+ which introduced the logged-models API (/api/2.0/mlflow/logged-models) not supported by AzureML tracking server, causing mlflow.sklearn.log_model() to fail with 404.

Changes:
- Use autolog(log_models=False) to prevent autolog from calling the unsupported API
- Replace mlflow.sklearn.log_model() with save_model + log_artifacts + register_model which use older, supported MLflow endpoints

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
