### PR TITLE
fix: pin mlflow<2.19 in 1c_pipeline_with_hyperparameter_sweep to fix …

### DIFF
--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/predict.yml
@@ -15,6 +15,7 @@ outputs:
 code: ./predict-src
 environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
 command: >-
+  pip install 'mlflow<2.19' -q &&
   python predict.py 
   --model ${{inputs.model}} 
   --test_data ${{inputs.test_data}} 

--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/train.yml
@@ -62,6 +62,7 @@ code: ./train-src
 environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest
 
 command: >-
+  pip install 'mlflow<2.19' -q &&
   python train.py 
   --data ${{inputs.data}}
   --C ${{inputs.c_value}}


### PR DESCRIPTION

# Description


Problem
The pipeline_with_hyperparameter_sweep notebook (1c_pipeline_with_hyperparameter_sweep) has been failing since December 16, 2025 with a JobException on the /score_data pipeline step:

Root Cause
Around December 16, 2025, the curated environment sklearn-1.5/labels/latest was updated to include MLflow 2.19+. This version introduced the logged-models API, which is not supported by the AzureML tracking server.

This breaks two things in the pipeline:

Train step: mlflow.autolog() fails to properly log/save the model via the AzureML backend
Predict/score_data step: mlflow.sklearn.load_model() fails to load the model output from the sweep step
The train step appeared to succeed but produced corrupted or incompatible model artifacts, causing the downstream score_data step to fail.

Fix
Pinned mlflow<2.19 at runtime in both component YAML commands:

train.yml — Added pip install 'mlflow<2.19' -q && before python train.py
predict.yml — Added pip install 'mlflow<2.19' -q && before python predict.py
This downgrades MLflow to a compatible version before executing the scripts, restoring compatibility with the AzureML tracking server. 


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
