### PR TITLE
fix: update env_train Dockerfile from Python 3.8 to 3.10

### DIFF
--- a/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
@@ -19,6 +19,7 @@ on:
       - sdk/python/dev-requirements.txt
       - infra/bootstrapping/**
       - sdk/python/setup.sh
+      - cli/jobs/pipelines-with-components/nyc_taxi_data_regression/**
 
 permissions:
   id-token: write

--- a/cli/jobs/pipelines-with-components/nyc_taxi_data_regression/env_train/Dockerfile
+++ b/cli/jobs/pipelines-with-components/nyc_taxi_data_regression/env_train/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:3.8.13
+FROM python:3.10
 
 # Install pip dependencies
-RUN pip install 'matplotlib>=3.3,<3.4' \
-                'psutil>=5.8,<5.9' \
-                'tqdm>=4.59,<4.60' \
-                'pandas>=1.1,<1.2' \
-                'scipy>=1.5,<1.6' \
-                'numpy>=1.10,<1.20' \
+RUN pip install 'matplotlib' \
+                'psutil' \
+                'tqdm' \
+                'pandas' \
+                'scipy' \
+                'numpy<2' \
                 'ipykernel~=6.0' \
                 'azureml-core' \
                 'azureml-defaults' \


### PR DESCRIPTION
Python 3.8 is EOL. The AzureML inference builder on ubuntu22.04 can no longer create containers with Python 3.8, causing ImageBuildFailure when deploying MLflow models trained with this environment. Update base image to python:3.10 and loosen dependency pins for compatibility.

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
