### PR TITLE
fix: missing inference packages and mlflow version pin for tutorial CI

### DIFF
--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
@@ -8,6 +8,6 @@ dependencies:
   - cloudpickle==2.2.0
   - psutil==5.8.0
   - scikit-learn==0.24.2
-  - azureml-ai-monitoring~=0.1.0b1
+  - azureml-ai-monitoring
   - azureml-contrib-services
 name: mlflow-env

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
@@ -8,4 +8,5 @@ dependencies:
   - cloudpickle==2.2.0
   - psutil==5.8.0
   - scikit-learn==0.24.2
+  - azureml-ai-monitoring~=0.1.0b1
 name: mlflow-env

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
@@ -9,4 +9,5 @@ dependencies:
   - psutil==5.8.0
   - scikit-learn==0.24.2
   - azureml-ai-monitoring~=0.1.0b1
+  - azureml-contrib-services
 name: mlflow-env

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
@@ -2,3 +2,4 @@ mlflow
 cloudpickle==2.2.0
 psutil==5.8.0
 scikit-learn==0.24.2
+azureml-ai-monitoring~=0.1.0b1

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
@@ -3,3 +3,4 @@ cloudpickle==2.2.0
 psutil==5.8.0
 scikit-learn==0.24.2
 azureml-ai-monitoring~=0.1.0b1
+azureml-contrib-services

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
@@ -2,5 +2,5 @@ mlflow
 cloudpickle==2.2.0
 psutil==5.8.0
 scikit-learn==0.24.2
-azureml-ai-monitoring~=0.1.0b1
+azureml-ai-monitoring
 azureml-contrib-services

--- a/tutorials/get-started-notebooks/pipeline.ipynb
+++ b/tutorials/get-started-notebooks/pipeline.ipynb
@@ -677,7 +677,7 @@
     "  # for this step, we'll use an AzureML curate environment\n",
     "  azureml://registries/azureml/environments/sklearn-1.5/labels/latest\n",
     "command: >-\n",
-    "  python train.py \n",
+    "  pip install 'mlflow<2.19' -q && python train.py \n",
     "  --train_data ${{inputs.train_data}} \n",
     "  --test_data ${{inputs.test_data}} \n",
     "  --learning_rate ${{inputs.learning_rate}}\n",


### PR DESCRIPTION
# Description

Fix CI failures in get-started-notebooks deploy and pipeline tutorials

What was failing

deploy-model.ipynb: Endpoint containers were crashing on boot with missing module errors (azureml.ai.monitoring, then azureml.contrib) because the model's conda environment didn't include packages now required by the updated inference base image.
pipeline.ipynb: Training step was failing due to a breaking change in MLflow 2.19.
What was fixed

Added azureml-ai-monitoring and azureml-contrib-services to the model's conda.yaml and requirements.txt.
Pinned mlflow<2.19 in the pipeline component command in pipeline.ipynb

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
