### PR TITLE
fix monitoring dependency notebook

### DIFF
--- a/sdk/python/assets/assets-in-registry/artifacts/model/conda.yaml
+++ b/sdk/python/assets/assets-in-registry/artifacts/model/conda.yaml
@@ -5,6 +5,8 @@ dependencies:
 - pip<=22.0.4
 - pip:
   - mlflow
+  - azureml-ai-monitoring
+  - azureml-contrib-services
   - cloudpickle==2.2.0
   - psutil==5.8.0
   - scikit-learn==1.2.2


### PR DESCRIPTION
# Description
What was failing

SDK assets : Endpoint containers were crashing on boot with missing module errors (azureml.ai.monitoring, then azureml.contrib) because the model's conda environment didn't include packages now required by the updated inference base image.
# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
