### PR TITLE
Fix mnist parallel pipeline EOL base image

### DIFF
--- a/cli/jobs/pipelines/mnist-batch-identification-using-parallel/pipeline.yml
+++ b/cli/jobs/pipelines/mnist-batch-identification-using-parallel/pipeline.yml
@@ -22,7 +22,7 @@ jobs:
     environment:
         name: "prepare_data_environment"
         version: 1
-        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
+        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04
         conda_file: ./environment/environment_prepare.yml
 
   predict_digits_mnist:
@@ -60,7 +60,7 @@ jobs:
       environment:
         name: "batch_environment"
         version: 1
-        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
+        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04
         conda_file: ./environment/environment_parallel.yml
       program_arguments: >-
         --model ${{inputs.score_model}}


### PR DESCRIPTION
## Summary
- replace EOL Azure ML base image in mnist parallel pipeline sample
- switch from ubuntu20.04 OpenMPI image to ubuntu22.04 image
- keep pipeline behavior unchanged

## Why
Pipeline run failed because the previous curated image hit EOL brownout.

## Validation
- verified image references updated in pipeline yaml
