### PR TITLE
Fix iris parallel pipeline: upgrade Python 3.7 -> 3.9 (TypedDict import error)

### DIFF
--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
@@ -2,7 +2,7 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.7.6
+  - python=3.9
   - pip
   - pip:
       - mlflow
@@ -12,5 +12,5 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn==0.20.3
-      - cloudpickle==1.1.1
+      - scikit-learn
+      - cloudpickle

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/pipeline.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/pipeline.yml
@@ -46,7 +46,7 @@ jobs:
       entry_script: iris_prediction.py
       environment:
         name: "prs-env"
-        version: 2
+        version: 1
         image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
         conda_file: ./environment/environment_parallel.yml
       program_arguments: >-

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/pipeline.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/pipeline.yml
@@ -46,7 +46,7 @@ jobs:
       entry_script: iris_prediction.py
       environment:
         name: "prs-env"
-        version: 1
+        version: 2
         image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
         conda_file: ./environment/environment_parallel.yml
       program_arguments: >-


### PR DESCRIPTION
## Problem

Running the `cli/jobs/pipelines/iris-batch-prediction-using-parallel` sample fails in the parallel-run-step driver with:

`
 cannot import name 'TypedDict' from 'typing' (/azureml-envs/.../python3.7/typing.py)
 Azure Machine Learning Batch Inference End
 SystemExit: 42
`

`TypedDict` was only added to `typing` in Python 3.8, but the inline environment pinned `python=3.7.6`.

## Fix

- `environment/environment_parallel.yml`: `python=3.7.6` -> `python=3.9`.
- Drop ancient pins `scikit-learn==0.20.3` and `cloudpickle==1.1.1` which are incompatible with Python 3.9.
- `pipeline.yml`: bump inline environment `version: 1` -> `2` so AzureML rebuilds the image instead of reusing the cached Python 3.7 one.