### PR TITLE
Fix mnist & iris parallel pipelines: bump to py3.8 + ubuntu22.04 image

### DIFF
--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
@@ -12,5 +12,5 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn==0.24.2
+      - scikit-learn==1.1.3
       - cloudpickle==2.2.1

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
@@ -2,7 +2,7 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.7.6
+  - python=3.8
   - pip
   - pip:
       - mlflow
@@ -12,5 +12,5 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn==0.20.3
-      - cloudpickle==1.1.1
+      - scikit-learn==0.24.2
+      - cloudpickle==2.2.1

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
@@ -12,5 +12,5 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn==1.1.3
+      - scikit-learn==0.24.2
       - cloudpickle==2.2.1

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
@@ -12,5 +12,5 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn==0.24.2
+      - scikit-learn==0.23.2
       - cloudpickle==2.2.1

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/environment/environment_parallel.yml
@@ -13,4 +13,5 @@ dependencies:
       - pillow
       - azureml-core
       - scikit-learn==0.23.2
+      - numpy<1.24
       - cloudpickle==2.2.1

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/pipeline.yml
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/pipeline.yml
@@ -47,7 +47,7 @@ jobs:
       environment:
         name: "prs-env"
         version: 1
-        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
+        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04
         conda_file: ./environment/environment_parallel.yml
       program_arguments: >-
         --model ${{inputs.score_model}}

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
@@ -25,28 +25,15 @@ def init():
 
     global iris_model
 
-    try:
-        iris_model = load_model(args.model)
-    except Exception as e:
-        import traceback
-        print("INIT_ERROR:", repr(e), flush=True)
-        traceback.print_exc()
-        raise
+    iris_model = load_model(args.model)
 
 
 def run(input_data):
-    try:
-        num_rows, num_cols = input_data.shape
-        print("RUN_SHAPE:", num_rows, num_cols, flush=True)
-        pred = iris_model.predict(input_data).reshape((num_rows, 1))
+    num_rows, num_cols = input_data.shape
+    pred = iris_model.predict(input_data).reshape((num_rows, 1))
 
-        # cleanup output
-        result = input_data.drop(input_data.columns[4:], axis=1)
-        result["variety"] = pred
+    # cleanup output
+    result = input_data.drop(input_data.columns[4:], axis=1)
+    result["variety"] = pred
 
-        return result
-    except Exception as e:
-        import traceback
-        print("RUN_ERROR:", repr(e), flush=True)
-        traceback.print_exc()
-        raise
+    return result

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
@@ -25,15 +25,28 @@ def init():
 
     global iris_model
 
-    iris_model = load_model(args.model)
+    try:
+        iris_model = load_model(args.model)
+    except Exception as e:
+        import traceback
+        print("INIT_ERROR:", repr(e), flush=True)
+        traceback.print_exc()
+        raise
 
 
 def run(input_data):
-    num_rows, num_cols = input_data.shape
-    pred = iris_model.predict(input_data).reshape((num_rows, 1))
+    try:
+        num_rows, num_cols = input_data.shape
+        print("RUN_SHAPE:", num_rows, num_cols, flush=True)
+        pred = iris_model.predict(input_data).reshape((num_rows, 1))
 
-    # cleanup output
-    result = input_data.drop(input_data.columns[4:], axis=1)
-    result["variety"] = pred
+        # cleanup output
+        result = input_data.drop(input_data.columns[4:], axis=1)
+        result["variety"] = pred
 
-    return result
+        return result
+    except Exception as e:
+        import traceback
+        print("RUN_ERROR:", repr(e), flush=True)
+        traceback.print_exc()
+        raise

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
@@ -25,28 +25,15 @@ def init():
 
     global iris_model
 
-    try:
-        iris_model = load_model(args.model)
-    except Exception as e:
-        import traceback
-        print("INIT_ERROR:", repr(e), flush=True)
-        traceback.print_exc()
-        raise
+    iris_model = load_model(args.model)
 
 
 def run(input_data):
-    try:
-        num_rows, num_cols = input_data.shape
-        print("RUN_SHAPE:", num_rows, num_cols, "cols=", list(input_data.columns), flush=True)
-        pred = iris_model.predict(input_data).reshape((num_rows, 1))
+    num_rows, num_cols = input_data.shape
+    pred = iris_model.predict(input_data).reshape((num_rows, 1))
 
-        # cleanup output
-        result = input_data.drop(input_data.columns[4:], axis=1)
-        result["variety"] = pred
+    # cleanup output
+    result = input_data.drop(input_data.columns[4:], axis=1)
+    result["variety"] = pred
 
-        return result
-    except Exception as e:
-        import traceback
-        print("RUN_ERROR:", repr(e), flush=True)
-        traceback.print_exc()
-        raise
+    return result

--- a/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
+++ b/cli/jobs/pipelines/iris-batch-prediction-using-parallel/script/iris_prediction.py
@@ -25,15 +25,28 @@ def init():
 
     global iris_model
 
-    iris_model = load_model(args.model)
+    try:
+        iris_model = load_model(args.model)
+    except Exception as e:
+        import traceback
+        print("INIT_ERROR:", repr(e), flush=True)
+        traceback.print_exc()
+        raise
 
 
 def run(input_data):
-    num_rows, num_cols = input_data.shape
-    pred = iris_model.predict(input_data).reshape((num_rows, 1))
+    try:
+        num_rows, num_cols = input_data.shape
+        print("RUN_SHAPE:", num_rows, num_cols, "cols=", list(input_data.columns), flush=True)
+        pred = iris_model.predict(input_data).reshape((num_rows, 1))
 
-    # cleanup output
-    result = input_data.drop(input_data.columns[4:], axis=1)
-    result["variety"] = pred
+        # cleanup output
+        result = input_data.drop(input_data.columns[4:], axis=1)
+        result["variety"] = pred
 
-    return result
+        return result
+    except Exception as e:
+        import traceback
+        print("RUN_ERROR:", repr(e), flush=True)
+        traceback.print_exc()
+        raise

--- a/cli/jobs/pipelines/mnist-batch-identification-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/mnist-batch-identification-using-parallel/environment/environment_parallel.yml
@@ -12,7 +12,7 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn==0.24.2
+      - scikit-learn==1.1.3
       - cloudpickle==2.2.1
-      - tensorflow==2.11.0
-      - protobuf==3.20.3
+      - tensorflow==2.13.1
+      - protobuf>=3.20.3,<5

--- a/cli/jobs/pipelines/mnist-batch-identification-using-parallel/environment/environment_parallel.yml
+++ b/cli/jobs/pipelines/mnist-batch-identification-using-parallel/environment/environment_parallel.yml
@@ -2,7 +2,7 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.7.6
+  - python=3.8
   - pip
   - pip:
       - mlflow
@@ -12,7 +12,7 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn~=0.20.0
-      - cloudpickle==1.1.1
-      - tensorflow==1.15.2
-      - protobuf==3.20.0
+      - scikit-learn==0.24.2
+      - cloudpickle==2.2.1
+      - tensorflow==2.11.0
+      - protobuf==3.20.3

--- a/cli/jobs/pipelines/mnist-batch-identification-using-parallel/pipeline.yml
+++ b/cli/jobs/pipelines/mnist-batch-identification-using-parallel/pipeline.yml
@@ -22,7 +22,7 @@ jobs:
     environment:
         name: "prepare_data_environment"
         version: 1
-        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
+        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04
         conda_file: ./environment/environment_prepare.yml
 
   predict_digits_mnist:
@@ -60,7 +60,7 @@ jobs:
       environment:
         name: "batch_environment"
         version: 1
-        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
+        image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04
         conda_file: ./environment/environment_parallel.yml
       program_arguments: >-
         --model ${{inputs.score_model}}

--- a/cli/jobs/pipelines/mnist-batch-identification-using-parallel/script/digit_identification.py
+++ b/cli/jobs/pipelines/mnist-batch-identification-using-parallel/script/digit_identification.py
@@ -4,8 +4,10 @@
 import os
 import numpy as np
 import argparse
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from PIL import Image
+
+tf.disable_v2_behavior()
 
 
 def init():


### PR DESCRIPTION
# Description

**Why it broke** 
PRS driver now requires Python 3.8+ (from typing import TypedDict); envs were pinned to python=3.7.6.
Base image openmpi4.1.0-ubuntu20.04 reached EOL.

**Fix**
Both pipelines:

 pipeline.yml: image → openmpi4.1.0-ubuntu22.04
environment_parallel.yml: python=3.7.6 → python=3.8

iris (env-only): pin scikit-learn==0.23.2 (legacy pickle compat), numpy<1.24 (sklearn 0.23 uses removed np.float), cloudpickle==2.2.1.

mnist: pin tensorflow==2.13.1 (TF 1.15 has no py3.8 wheels) + protobuf>=3.20.3,<5; add import tensorflow.compat.v1 as tf; tf.disable_v2_behavior() (mandatory TF1→TF2 shim).

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
