### PR TITLE
Fix 1g_pipeline_with_parallel_nodes: bump to py3.8 + ubuntu22.04 image

### DIFF
--- a/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb
+++ b/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb
@@ -215,7 +215,7 @@
     "        code=\"./src\",\n",
     "        entry_script=\"tabular_batch_inference.py\",\n",
     "        environment=Environment(\n",
-    "            image=\\\"mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04\\\",\n",
+    "            image=\"mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04\",\n",
     "            conda_file=\"./src/environment_parallel.yml\",\n",
     "        ),\n",
     "        program_arguments=\"--model ${{inputs.score_model}} \"\n",

--- a/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb
+++ b/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/pipeline_with_parallel_nodes.ipynb
@@ -215,7 +215,7 @@
     "        code=\"./src\",\n",
     "        entry_script=\"tabular_batch_inference.py\",\n",
     "        environment=Environment(\n",
-    "            image=\"mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04\",\n",
+    "            image=\\\"mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04\\\",\n",
     "            conda_file=\"./src/environment_parallel.yml\",\n",
     "        ),\n",
     "        program_arguments=\"--model ${{inputs.score_model}} \"\n",

--- a/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/src/environment_parallel.yml
+++ b/sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/src/environment_parallel.yml
@@ -2,7 +2,7 @@ name: prs-env
 channels:
   - conda-forge
 dependencies:
-  - python=3.7.6
+  - python=3.8
   - pip
   - pip:
       - mlflow
@@ -12,5 +12,6 @@ dependencies:
       - pandas
       - pillow
       - azureml-core
-      - scikit-learn==0.20.3
-      - cloudpickle==1.1.1
+      - scikit-learn==0.23.2
+      - numpy<1.24
+      - cloudpickle==2.2.1


### PR DESCRIPTION
# Description

**Root Cause**

PRS driver now requires Python 3.8+ (from typing import TypedDict). The env was pinned to python=3.7.6, causing cannot import name 'TypedDict' from 'typing' and SystemExit: 42.
Base image openmpi4.1.0-ubuntu20.04 reached EOL.

**Changes**
sdk/python/jobs/pipelines/1g_pipeline_with_parallel_nodes/:

src/environment_parallel.yml:

python=3.7.6 → python=3.8
scikit-learn==0.20.3 → scikit-learn==0.23.2 (legacy iris pickle compat: keeps [sklearn.linear_model.logistic]shim removed in 0.24)
cloudpickle==1.1.1 → cloudpickle==2.2.1 (py3.8 wheels)
added numpy<1.24 (sklearn 0.23 uses np.float, removed in numpy 1.24)
[pipeline_with_parallel_nodes.ipynb] : image openmpi4.1.0-ubuntu20.04 → openmpi4.1.0-ubuntu22.04

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
