### PR TITLE
Fix uai notebook: handle azure-mgmt-msi Identity schema change

### DIFF
--- a/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
+++ b/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
@@ -539,10 +539,10 @@
     "uai_identity = msi_client.user_assigned_identities.get(\n",
     "    resource_group_name=resource_group, resource_name=uai_name\n",
     ")\n",
-    "# Handle azure-mgmt-msi SDK compatibility: newer versions nest these under properties\n",
-    "uai_dict = uai_identity.as_dict()\n",
-    "uai_principal_id = uai_dict.get(\"principal_id\") or uai_dict.get(\"properties\", {}).get(\"principal_id\")\n",
-    "uai_client_id = uai_dict.get(\"client_id\") or uai_dict.get(\"properties\", {}).get(\"client_id\")"
+    "_uai = uai_identity.as_dict()\n",
+    "_uai = _uai.get(\"properties\", _uai)\n",
+    "uai_principal_id = _uai.get(\"principalId\") or _uai.get(\"principal_id\")\n",
+    "uai_client_id = _uai.get(\"clientId\") or _uai.get(\"client_id\")"
    ]
   },
   {

--- a/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
+++ b/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
@@ -28,9 +28,9 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --pre \"azure-mgmt-msi<8\"\n",
+    "%pip install --pre azure-mgmt-msi\n",
     "%pip install --pre azure-mgmt-storage\n",
-    "%pip install --pre \"azure-mgmt-authorization<5\""
+    "%pip install --pre azure-mgmt-authorization"
    ]
   },
   {
@@ -539,8 +539,10 @@
     "uai_identity = msi_client.user_assigned_identities.get(\n",
     "    resource_group_name=resource_group, resource_name=uai_name\n",
     ")\n",
-    "uai_principal_id = uai_identity.principal_id\n",
-    "uai_client_id = uai_identity.client_id"
+    "_uai = uai_identity.as_dict()\n",
+    "_uai = _uai.get(\"properties\", _uai)\n",
+    "uai_principal_id = _uai.get(\"principalId\") or _uai.get(\"principal_id\")\n",
+    "uai_client_id = _uai.get(\"clientId\") or _uai.get(\"client_id\")"
    ]
   },
   {

--- a/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
+++ b/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
@@ -28,9 +28,9 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --pre azure-mgmt-msi\n",
+    "%pip install --pre \"azure-mgmt-msi<8\"\n",
     "%pip install --pre azure-mgmt-storage\n",
-    "%pip install --pre azure-mgmt-authorization"
+    "%pip install --pre \"azure-mgmt-authorization<5\""
    ]
   },
   {
@@ -539,10 +539,8 @@
     "uai_identity = msi_client.user_assigned_identities.get(\n",
     "    resource_group_name=resource_group, resource_name=uai_name\n",
     ")\n",
-    "_uai = uai_identity.as_dict()\n",
-    "_uai = _uai.get(\"properties\", _uai)\n",
-    "uai_principal_id = _uai.get(\"principalId\") or _uai.get(\"principal_id\")\n",
-    "uai_client_id = _uai.get(\"clientId\") or _uai.get(\"client_id\")"
+    "uai_principal_id = uai_identity.principal_id\n",
+    "uai_client_id = uai_identity.client_id"
    ]
   },
   {

--- a/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
+++ b/sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-uai.ipynb
@@ -539,8 +539,10 @@
     "uai_identity = msi_client.user_assigned_identities.get(\n",
     "    resource_group_name=resource_group, resource_name=uai_name\n",
     ")\n",
-    "uai_principal_id = uai_identity.principal_id\n",
-    "uai_client_id = uai_identity.client_id"
+    "# Handle azure-mgmt-msi SDK compatibility: newer versions nest these under properties\n",
+    "uai_dict = uai_identity.as_dict()\n",
+    "uai_principal_id = uai_dict.get(\"principal_id\") or uai_dict.get(\"properties\", {}).get(\"principal_id\")\n",
+    "uai_client_id = uai_dict.get(\"client_id\") or uai_dict.get(\"properties\", {}).get(\"client_id\")"
    ]
   },
   {


### PR DESCRIPTION
# Description

**Root Cause:** 
CI passed on May 31, failing since June 1 with:
  AttributeError: 'Identity' object has no attribute 'principal_id'

A new azure-mgmt-msi pre-release (picked up by %pip install --pre azure-mgmt-msi) moved principal_id / client_id under properties and renamed them to camelCase. Neither the notebook nor the workflow changed.

**Fix:**

In the get-uai-details cell, read the IDs via as_dict() so it works with both old and new schemas:

_uai = uai_identity.as_dict()
_uai = _uai.get("properties", _uai)
uai_principal_id = _uai.get("principalId") or _uai.get("principal_id")
uai_client_id    = _uai.get("clientId")    or _uai.get("client_id")




# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
