### PR TITLE
share-models: fix MLflow no-code deployment failing with ModuleNotFoundError: azureml.contrib

### DIFF
--- a/cli/jobs/pipelines-with-components/nyc_taxi_data_regression/train_src/train.py
+++ b/cli/jobs/pipelines-with-components/nyc_taxi_data_regression/train_src/train.py
@@ -85,7 +85,18 @@ print(trainX.columns)
 model = LinearRegression().fit(trainX, trainy)
 print(model.score(trainX, trainy))
 
-mlflow.sklearn.save_model(model, args.model_output)
+# Include packages required by AzureML's auto-generated MLflow inference
+# scoring script (mlflow_score_script.py) so no-code deployments of this
+# model build an inference environment that can import these modules.
+mlflow.sklearn.save_model(
+    model,
+    args.model_output,
+    extra_pip_requirements=[
+        "azureml-ai-monitoring",
+        "azureml-inference-server-http",
+        "azureml-contrib-services",
+    ],
+)
 
 # test_data = pd.DataFrame(testX, columns = )
 testX["cost"] = testy

--- a/sdk/python/assets/assets-in-registry/artifacts/model/conda.yaml
+++ b/sdk/python/assets/assets-in-registry/artifacts/model/conda.yaml
@@ -6,6 +6,7 @@ dependencies:
 - pip:
   - mlflow
   - azureml-ai-monitoring
+  - azureml-inference-server-http
   - azureml-contrib-services
   - cloudpickle==2.2.0
   - psutil==5.8.0

--- a/sdk/python/assets/assets-in-registry/artifacts/model/requirements.txt
+++ b/sdk/python/assets/assets-in-registry/artifacts/model/requirements.txt
@@ -1,4 +1,7 @@
 mlflow
+azureml-ai-monitoring
+azureml-inference-server-http
+azureml-contrib-services
 cloudpickle==2.2.0
 psutil==5.8.0
 scikit-learn==1.2.2


### PR DESCRIPTION
## Problem

The sample notebook `sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb` fails during `ManagedOnlineDeployment` of the MLflow `nyc-taxi-model` from the registry with:

```n ModuleNotFoundError: No module named 'azureml.contrib'
```

Root cause: the inference container ships `azureml-inference-server-http==1.3.4` whose `server/__init__.py` unconditionally imports `azureml.contrib.services.aml_request` at startup; the package is not present, so the server crashes before the user model loads.

## Fix

Add the missing/buggy deps to the MLflow model's pip requirements so AzureML's no-code deployment rebuilds the inference environment with working versions:

- `azureml-inference-server-http` - upgrades the buggy 1.3.4 to a version that handles the import safely
- `azureml-contrib-services` - provides the imported module
- `azureml-ai-monitoring` - referenced by the auto-generated `mlflow_score_script.py`

## Files changed

- `cli/jobs/pipelines-with-components/nyc_taxi_data_regression/train_src/train.py` - pass `extra_pip_requirements` to `mlflow.sklearn.save_model`, so models trained by this script (used across several pipeline samples) get the correct deps embedded in their MLflow env.
- `sdk/python/assets/assets-in-registry/artifacts/model/conda.yaml` - add `azureml-inference-server-http` (the other two already present).
- `sdk/python/assets/assets-in-registry/artifacts/model/requirements.txt` - add all three packages for parity with `conda.yaml`.

## Verification

Mirrors the working pattern from `tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb` (commit `2a4ac4721`), which fixed the same failure mode in CI by adding the same three packages to `extra_pip_requirements`.