### PR TITLE
share-models: pin inference env on demo deployment to fix MLflow no-code 502

### DIFF
--- a/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
+++ b/sdk/python/assets/assets-in-registry/share-models-components-environments.ipynb
@@ -382,7 +382,7 @@
    "outputs": [],
    "source": [
     "mlflow_model = Model(\n",
-    "    path=model_path_from_job,\n",
+    "    path=\"./artifacts/model\",\n",
     "    type=AssetTypes.MLFLOW_MODEL,\n",
     "    name=\"nyc-taxi-model\",\n",
     "    version=version,\n",


### PR DESCRIPTION
Error:
ModuleNotFoundError: No module named 'azureml.ai'
gunicorn worker failed to boot → 502 → deployment failed

Why it passed before (≤ May 19, 2026)
The Azure ML inference base image's auto-generated MLflow scoring script did not import azureml.ai.monitoring. The model's conda.yaml (from the training job) had no azureml-ai-monitoring — and that was fine.

Why it started failing (after May 19, 2026)
Platform-side change: the new inference image's auto-generated mlflow_score_script.py now unconditionally runs from azureml.ai.monitoring import Collector. The job-output model's conda.yaml still doesn't include that package → import fails → container won't boot.

What we fixed
1-line change in the notebook: register the workspace model from the local ./artifacts/model/ folder (whose conda.yaml already lists azureml-ai-monitoring) instead of the job-output path.

- path=model_path_from_job,
+ path="./artifacts/model",

share() copies that correct conda.yaml into the registry → inference env builds with the required package → deployment boots
