### PR TITLE
deploy-model tutorial: pin azureml-inference-server-http<1.3 for py3.…

### DIFF
--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
@@ -10,4 +10,7 @@ dependencies:
   - scikit-learn==0.24.2
   - azureml-ai-monitoring
   - azureml-contrib-services
+  # Pin inference server <1.3 to avoid _patch_azureml_contrib_services()
+  # import failure (introduced in 1.3.0). Versions >=1.4 dropped Python 3.8.
+  - azureml-inference-server-http<1.3
 name: mlflow-env

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
@@ -4,3 +4,6 @@ psutil==5.8.0
 scikit-learn==0.24.2
 azureml-ai-monitoring
 azureml-contrib-services
+# Pin inference server <1.3 to avoid _patch_azureml_contrib_services()
+# import failure (introduced in 1.3.0). Versions >=1.4 dropped Python 3.8.
+azureml-inference-server-http<1.3

--- a/tutorials/get-started-notebooks/quickstart.ipynb
+++ b/tutorials/get-started-notebooks/quickstart.ipynb
@@ -353,10 +353,13 @@
     "        registered_model_name=registered_model_name,\n",
     "    ),\n",
     "    code=\"./src/\",  # location of source code\n",
-    "    command=\"python main.py --data ${{inputs.data}} --test_train_ratio ${{inputs.test_train_ratio}} --learning_rate ${{inputs.learning_rate}} --registered_model_name ${{inputs.registered_model_name}}\",\n",
+    "    # Pin mlflow<3 because the curated sklearn-1.5 environment ships MLflow 3.x,\n",
+    "    # whose `mlflow.sklearn.log_model` calls the `/api/2.0/mlflow/logged-models`\n",
+    "    # endpoint that AzureML's MLflow tracking server does not yet support (404).\n",
+    "    command=\"pip install 'mlflow<3' -q && python main.py --data ${{inputs.data}} --test_train_ratio ${{inputs.test_train_ratio}} --learning_rate ${{inputs.learning_rate}} --registered_model_name ${{inputs.registered_model_name}}\",\n",
     "    environment=\"azureml://registries/azureml/environments/sklearn-1.5/labels/latest\",\n",
     "    display_name=\"credit_default_prediction\",\n",
-    ")"
+    ")\n"
    ]
   },
   {


### PR DESCRIPTION
…8 MLflow model

The credit_defaults_model MLflow no-code online deployment fails at container startup with ModuleNotFoundError: No module named 'azureml.contrib' because azureml-inference-server-http 1.3.0-1.3.4 unconditionally calls _patch_azureml_contrib_services() which imports azureml.contrib.services.

Adding azureml-contrib-services to the model's conda.yaml (PR #3928) is insufficient: AzureML's MLflow no-code env builder silently drops it during pip resolution (deployed pip freeze shows azureml-inference-server-http==1.3.4 and azureml-ai-monitoring==1.0.0 but no azureml-contrib-services).

Versions >=1.4 of the inference server removed the buggy patch path but dropped Python 3.8 support, and this MLflow model requires python=3.8.15. Pinning <1.3 forces resolution to 1.2.x which doesn't try to import the contrib module.

# Description


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
