### PR TITLE
deploy-model tutorial: pin azureml-inference-server-http<1.3 for py3.…

### DIFF
--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
@@ -10,7 +10,5 @@ dependencies:
   - scikit-learn==0.24.2
   - azureml-ai-monitoring
   - azureml-contrib-services
-  # Pin inference server <1.3 to avoid _patch_azureml_contrib_services()
-  # import failure (introduced in 1.3.0). Versions >=1.4 dropped Python 3.8.
   - azureml-inference-server-http<1.3
 name: mlflow-env

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/conda.yaml
@@ -10,4 +10,7 @@ dependencies:
   - scikit-learn==0.24.2
   - azureml-ai-monitoring
   - azureml-contrib-services
+  # Pin inference server <1.3 to avoid _patch_azureml_contrib_services()
+  # import failure (introduced in 1.3.0). Versions >=1.4 dropped Python 3.8.
+  - azureml-inference-server-http<1.3
 name: mlflow-env

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
@@ -4,6 +4,4 @@ psutil==5.8.0
 scikit-learn==0.24.2
 azureml-ai-monitoring
 azureml-contrib-services
-# Pin inference server <1.3 to avoid _patch_azureml_contrib_services()
-# import failure (introduced in 1.3.0). Versions >=1.4 dropped Python 3.8.
 azureml-inference-server-http<1.3

--- a/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
+++ b/tutorials/get-started-notebooks/deploy/credit_defaults_model/requirements.txt
@@ -4,3 +4,6 @@ psutil==5.8.0
 scikit-learn==0.24.2
 azureml-ai-monitoring
 azureml-contrib-services
+# Pin inference server <1.3 to avoid _patch_azureml_contrib_services()
+# import failure (introduced in 1.3.0). Versions >=1.4 dropped Python 3.8.
+azureml-inference-server-http<1.3

--- a/tutorials/get-started-notebooks/quickstart.ipynb
+++ b/tutorials/get-started-notebooks/quickstart.ipynb
@@ -353,7 +353,7 @@
     "        registered_model_name=registered_model_name,\n",
     "    ),\n",
     "    code=\"./src/\",  # location of source code\n",
-    "    command=\"python main.py --data ${{inputs.data}} --test_train_ratio ${{inputs.test_train_ratio}} --learning_rate ${{inputs.learning_rate}} --registered_model_name ${{inputs.registered_model_name}}\",\n",
+    "    command=\"pip install 'mlflow<3' -q && python main.py --data ${{inputs.data}} --test_train_ratio ${{inputs.test_train_ratio}} --learning_rate ${{inputs.learning_rate}} --registered_model_name ${{inputs.registered_model_name}}\",\n",
     "    environment=\"azureml://registries/azureml/environments/sklearn-1.5/labels/latest\",\n",
     "    display_name=\"credit_default_prediction\",\n",
     ")"


### PR DESCRIPTION

# Description
Why it passed before May 29: The MLflow inference base image shipped azureml-inference-server-http 1.2.x, which didn't try to import azureml.contrib.services.

Why it started failing after May 29: The image was refreshed and bumped to azureml-inference-server-http==1.3.4. The 1.3.x line unconditionally calls _patch_azureml_contrib_services(), which imports azureml.contrib.services — a package that isn't installed in the deployment env. Container startup crashes with ModuleNotFoundError: No module named 'azureml.contrib'.

What we fixed: Pin the server back to the 1.2.x line in the model's env so the buggy import path is never loaded. (We can't go to 1.4+, which fixed the bug, because 1.4 dropped Python 3.8 and this MLflow model requires py3.8.)
                                   
**+ - azureml-inference-server-http<1.3**

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
