### PR TITLE
Repro: update display_name on sweep pipeline job (DRAFT)

### DIFF
--- a/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb
+++ b/sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb
@@ -208,6 +208,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## 2.3 Get and update the pipeline job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reproduce: fetch the just-submitted sweep pipeline job, update its display name,\n",
+    "# and call create_or_update to push the change back.\n",
+    "job_name = pipeline_job.name\n",
+    "fetched_job = ml_client.jobs.get(job_name)\n",
+    "print(fetched_job.display_name)\n",
+    "fetched_job.display_name = f\"{job_name}_updated\"\n",
+    "ml_client.jobs.create_or_update(fetched_job)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Next Steps\n",
     "You can see further examples of running a pipeline job [here](../)"
    ]


### PR DESCRIPTION
**Draft / repro only — do not merge.**

Adds a final section to sdk/python/jobs/pipelines/1c_pipeline_with_hyperparameter_sweep/pipeline_with_hyperparameter_sweep.ipynb to reproduce an issue with calling MLClient.jobs.create_or_update() on a fetched sweep pipeline job after only mutating display_name.

### Repro snippet added

```python
fetched_job = ml_client.jobs.get(pipeline_job.name)
print(fetched_job.display_name)
fetched_job.display_name = f"{pipeline_job.name}_updated"
ml_client.jobs.create_or_update(fetched_job)
```

### Steps
1. Run all cells in the notebook to submit the sweep pipeline job.
2. Run the new repro cell to attempt updating the display name.
3. Capture the resulting error / traceback (if any).