### PR TITLE
Fix e2e-ml-workflow deployment: disable autolog model registration

### DIFF
--- a/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb
+++ b/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb
@@ -308,6 +308,7 @@
                 "    - inference-schema[numpy-support]==1.3.0\n",
                 "    - xlrd==2.0.1\n",
                 "    - azureml-mlflow==1.42.0\n",
+                "    - azureml-ai-monitoring\n",
                 "    - mlflow==2.16.2"
             ]
         },
@@ -628,7 +629,7 @@
                 "mlflow.start_run()\n",
                 "\n",
                 "# enable autologging\n",
-                "mlflow.sklearn.autolog(log_models=False)\n",
+                "mlflow.sklearn.autolog()\n",
                 "\n",
                 "os.makedirs(\"./outputs\", exist_ok=True)\n",
                 "\n",

--- a/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb
+++ b/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb
@@ -628,7 +628,7 @@
                 "mlflow.start_run()\n",
                 "\n",
                 "# enable autologging\n",
-                "mlflow.sklearn.autolog()\n",
+                "mlflow.sklearn.autolog(log_models=False)\n",
                 "\n",
                 "os.makedirs(\"./outputs\", exist_ok=True)\n",
                 "\n",


### PR DESCRIPTION
## Problem
The [e2e-ml-workflow CI](https://github.com/Azure/azureml-examples/actions/runs/27154430534/job/80153505727) is failing with:
```
ModuleNotFoundError: No module named 'azureml'
```
The MLflow scoring script imports `azureml.ai.monitoring.Collector` but the package is missing from the deployed environment.

## Root Cause
`mlflow.sklearn.autolog()` auto-registers the model when `clf.fit()` runs, creating a model artifact **without** `azureml-ai-monitoring` in its conda.yaml. The explicit `mlflow.sklearn.log_model()` call below includes `extra_pip_requirements` with the needed packages, but the autolog-registered model (without those deps) was being deployed.

## Fix
Pass `log_models=False` to `autolog()` so only the explicit `log_model()` (which includes the required inference packages) registers the model.

## Change
```diff
- mlflow.sklearn.autolog()
+ mlflow.sklearn.autolog(log_models=False)
```
