### PR TITLE
Fix azureml-in-a-day deployment: add azureml-ai-monitoring to conda.yaml

### DIFF
--- a/tutorials/azureml-in-a-day/azureml-in-a-day.ipynb
+++ b/tutorials/azureml-in-a-day/azureml-in-a-day.ipynb
@@ -195,6 +195,7 @@
                 "    - xlrd==2.0.1\n",
                 "    - mlflow\n",
                 "    - azureml-mlflow\n",
+                "    - azureml-ai-monitoring\n",
                 "    - psutil\n",
                 "    - tqdm\n",
                 "    - ipykernel~=6.29\n",

--- a/tutorials/azureml-in-a-day/azureml-in-a-day.ipynb
+++ b/tutorials/azureml-in-a-day/azureml-in-a-day.ipynb
@@ -393,6 +393,7 @@
                 "        sk_model=clf,\n",
                 "        registered_model_name=args.registered_model_name,\n",
                 "        artifact_path=args.registered_model_name,\n",
+                "        extra_pip_requirements=[\"azureml-ai-monitoring\"],\n",
                 "    )\n",
                 "\n",
                 "    # Saving the model to a file\n",


### PR DESCRIPTION
## Problem
The [azureml-in-a-day CI](https://github.com/Azure/azureml-examples/actions/runs/27207603984/job/80380194292) is failing at endpoint invoke with:
```
HttpResponseError: An unexpected error occurred in scoring script.
```

The workflow was passing until recently but started failing consistently due to an Azure ML platform update that added `azureml.ai.monitoring` import to the auto-generated MLflow scoring script.

## Root Cause
The auto-generated MLflow scoring script (`mlflow_score_script.py`) imports `azureml.ai.monitoring.Collector`, but the model's conda environment does not include the `azureml-ai-monitoring` package.

## Fix
Add `azureml-ai-monitoring` to the training conda.yaml so it gets captured in the model's environment and is available at inference time.

## Change
```diff
    - mlflow
    - azureml-mlflow
+   - azureml-ai-monitoring
    - psutil
```
