### PR TITLE
Add scheduled GitHub Action to monitor a batch endpoint via MLflow

### DIFF
--- a/.github/workflows/monitor-batch.yml
+++ b/.github/workflows/monitor-batch.yml
@@ -1,0 +1,31 @@
+name: Monitor Batch Endpoint
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"   # every 30 mins
+  workflow_dispatch:
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          pip install -r tutorials/batch_endpoint_monitor/requirements.txt
+
+      - name: Run monitor script
+        env:
+          SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
+          WORKSPACE_NAME: ${{ secrets.WORKSPACE_NAME }}
+          BATCH_ENDPOINT_NAME: ${{ secrets.BATCH_ENDPOINT_NAME }}
+        run: |
+          python tutorials/batch_endpoint_monitor/monitor.py

--- a/tutorials/batch_endpoint_monitor/monitor.py
+++ b/tutorials/batch_endpoint_monitor/monitor.py
@@ -1,0 +1,33 @@
+import os
+import mlflow
+from azure.ai.ml import MLClient
+from azure.identity import DefaultAzureCredential
+
+subscription_id = os.environ["SUBSCRIPTION_ID"]
+resource_group = os.environ["RESOURCE_GROUP"]
+workspace = os.environ["WORKSPACE_NAME"]
+endpoint_name = os.environ["BATCH_ENDPOINT_NAME"]
+
+ml_client = MLClient(
+    DefaultAzureCredential(),
+    subscription_id,
+    resource_group,
+    workspace,
+)
+
+mlflow.set_tracking_uri(ml_client.workspaces.get(workspace).mlflow_tracking_uri)
+
+runs = mlflow.search_runs(
+    experiment_names=[endpoint_name],
+    output_format="list",
+)
+
+failed = False
+
+for run in runs:
+    print(run.info.run_id, run.info.status)
+    if run.info.status not in ["FINISHED", "RUNNING"]:
+        failed = True
+
+if failed:
+    raise Exception("Some runs failed")

--- a/tutorials/batch_endpoint_monitor/requirements.txt
+++ b/tutorials/batch_endpoint_monitor/requirements.txt
@@ -1,0 +1,4 @@
+azure-ai-ml
+azure-identity
+mlflow
+azureml-mlflow


### PR DESCRIPTION
## Summary
Adds a scheduled GitHub Action that checks an Azure ML batch endpoint's recent runs via MLflow and fails the workflow if any run is in a non-healthy state.

## Changes
- `.github/workflows/monitor-batch.yml` - cron (every 30 min) + `workflow_dispatch` trigger; wires four repo secrets into env vars and runs the monitor script.
- `tutorials/batch_endpoint_monitor/monitor.py` - uses `azure-ai-ml` + `mlflow` to list runs for the endpoint experiment and raises if any run status is not `FINISHED` or `RUNNING`.
- `tutorials/batch_endpoint_monitor/requirements.txt` - `azure-ai-ml`, `azure-identity`, `mlflow`, `azureml-mlflow`.

## Required repo secrets
- `SUBSCRIPTION_ID`
- `RESOURCE_GROUP`
- `WORKSPACE_NAME`
- `BATCH_ENDPOINT_NAME`

## Notes
- `DefaultAzureCredential` is used; for unattended CI typically wire OIDC / federated credentials or a service principal.
- Draft - opening for review before enabling the schedule.