### PR TITLE
Harden amlsecscan scheduled entrypoint ownership

### DIFF
--- a/setup/setup-ci/security-scanner/README.md
+++ b/setup/setup-ci/security-scanner/README.md
@@ -176,8 +176,12 @@ After installation, the following files should be present on the Compute Instanc
 File|Description
 --|--
 `/home/azureuser/.amlsecscan/config.json`|Scanner configuration
+`/home/azureuser/.amlsecscan/amlsecscan.py`|Scanner executable used by the CRON entry point
 `/home/azureuser/.amlsecscan/run.sh`|Scanner CRON entry point
+`/var/lib/amlsecscan`|Scanner working directory for generated scan artifacts
 `/etc/cron.d/amlsecscan`|Scanner CRON schedule
+
+The files under `/home/azureuser/.amlsecscan` are owned by root so unprivileged users cannot replace the scheduled scanner entry point.
 
 ### Verify that resource-usage limits are in place
 

--- a/setup/setup-ci/security-scanner/README.md
+++ b/setup/setup-ci/security-scanner/README.md
@@ -156,7 +156,7 @@ If logs are missing in Log Analytics, scans may not be running. Local logs are a
 
 The CRON configuration is located at `/etc/cron.d/amlsecscan` .
 
-Scans can be run manually with higher verbosity to get more details: `sudo /home/azureuser/.amlsecscan/run.sh scan all -ll DEBUG` .
+Scans can be run manually with higher verbosity to get more details: `sudo /opt/amlsecscan/run.sh scan all -ll DEBUG` .
 
 ### Investigate Compute Instance deployment failures
 
@@ -175,13 +175,13 @@ After installation, the following files should be present on the Compute Instanc
 
 File|Description
 --|--
-`/home/azureuser/.amlsecscan/config.json`|Scanner configuration
-`/home/azureuser/.amlsecscan/amlsecscan.py`|Scanner executable used by the CRON entry point
-`/home/azureuser/.amlsecscan/run.sh`|Scanner CRON entry point
+`/opt/amlsecscan/config.json`|Scanner configuration
+`/opt/amlsecscan/amlsecscan.py`|Scanner executable used by the CRON entry point
+`/opt/amlsecscan/run.sh`|Scanner CRON entry point
 `/var/lib/amlsecscan`|Scanner working directory for generated scan artifacts
 `/etc/cron.d/amlsecscan`|Scanner CRON schedule
 
-The files under `/home/azureuser/.amlsecscan` are owned by root so unprivileged users cannot replace the scheduled scanner entry point.
+The files under `/opt/amlsecscan` are owned by root and located under a root-controlled parent directory so unprivileged users cannot replace the scheduled scanner entry point.
 
 ### Verify that resource-usage limits are in place
 

--- a/setup/setup-ci/security-scanner/README.md
+++ b/setup/setup-ci/security-scanner/README.md
@@ -156,7 +156,7 @@ If logs are missing in Log Analytics, scans may not be running. Local logs are a
 
 The CRON configuration is located at `/etc/cron.d/amlsecscan` .
 
-Scans can be run manually with higher verbosity to get more details: `sudo /home/azureuser/.amlsecscan/run.sh scan all -ll DEBUG` .
+Scans can be run manually with higher verbosity to get more details: `sudo /etc/amlsecscan/run.sh scan all -ll DEBUG` .
 
 ### Investigate Compute Instance deployment failures
 
@@ -175,13 +175,13 @@ After installation, the following files should be present on the Compute Instanc
 
 File|Description
 --|--
-`/home/azureuser/.amlsecscan/config.json`|Scanner configuration
-`/home/azureuser/.amlsecscan/amlsecscan.py`|Scanner executable used by the CRON entry point
-`/home/azureuser/.amlsecscan/run.sh`|Scanner CRON entry point
+`/etc/amlsecscan/config.json`|Scanner configuration
+`/etc/amlsecscan/amlsecscan.py`|Scanner executable used by the CRON entry point
+`/etc/amlsecscan/run.sh`|Scanner CRON entry point
 `/var/lib/amlsecscan`|Scanner working directory for generated scan artifacts
 `/etc/cron.d/amlsecscan`|Scanner CRON schedule
 
-The files under `/home/azureuser/.amlsecscan` are owned by root so unprivileged users cannot replace the scheduled scanner entry point.
+The scheduled scanner entry point is stored under `/etc/amlsecscan` and owned by root so unprivileged users cannot replace the scheduled scanner entry point through the Azure ML user home directory.
 
 ### Verify that resource-usage limits are in place
 

--- a/setup/setup-ci/security-scanner/amlsecscan.py
+++ b/setup/setup-ci/security-scanner/amlsecscan.py
@@ -30,7 +30,7 @@ _azure_ml_resource_id = (
 )  # Get the ARM Resource ID of the Azure ML Workspace we are running on
 
 # Configuration priority: 1) command-line parameters, 2) local config file, 3) global config file
-_config_folder_path = "/home/azureuser/.amlsecscan"
+_config_folder_path = "/opt/amlsecscan"
 _global_config_path = _config_folder_path + "/config.json"
 _installed_scanner_path = _config_folder_path + "/amlsecscan.py"
 _state_folder_path = "/var/lib/amlsecscan"

--- a/setup/setup-ci/security-scanner/amlsecscan.py
+++ b/setup/setup-ci/security-scanner/amlsecscan.py
@@ -547,7 +547,9 @@ def _scan_vulnerabilities(telemetry):
         for env_name in (
             entry.name for entry in os.scandir("/anaconda/envs") if entry.is_dir()
         ):
-            requirements_path = f"{_state_folder_path}/anaconda/{env_name}/requirements.txt"
+            requirements_path = (
+                f"{_state_folder_path}/anaconda/{env_name}/requirements.txt"
+            )
             _logger.info(
                 f"Saving pip freeze of conda environment {env_name} to {requirements_path}"
             )

--- a/setup/setup-ci/security-scanner/amlsecscan.py
+++ b/setup/setup-ci/security-scanner/amlsecscan.py
@@ -30,7 +30,7 @@ _azure_ml_resource_id = (
 )  # Get the ARM Resource ID of the Azure ML Workspace we are running on
 
 # Configuration priority: 1) command-line parameters, 2) local config file, 3) global config file
-_config_folder_path = "/home/azureuser/.amlsecscan"
+_config_folder_path = "/etc/amlsecscan"
 _global_config_path = _config_folder_path + "/config.json"
 _installed_scanner_path = _config_folder_path + "/amlsecscan.py"
 _state_folder_path = "/var/lib/amlsecscan"

--- a/setup/setup-ci/security-scanner/amlsecscan.py
+++ b/setup/setup-ci/security-scanner/amlsecscan.py
@@ -12,8 +12,10 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
+import tempfile
 import time
 import requests
 from urllib.parse import urlparse
@@ -81,7 +83,44 @@ def _run(command, check=True):
         raise
 
 
-def _recreate_owned_directory(path, user, group, mode):
+def _is_trusted_root_directory(path, allowed_entries=None):
+    try:
+        directory_stat = os.lstat(path)
+    except FileNotFoundError:
+        return False
+
+    if (
+        not stat.S_ISDIR(directory_stat.st_mode)
+        or directory_stat.st_uid != 0
+        or directory_stat.st_gid != 0
+        or stat.S_IMODE(directory_stat.st_mode) & 0o022
+    ):
+        return False
+
+    if allowed_entries is None:
+        return True
+
+    for entry in os.scandir(path):
+        if entry.name not in allowed_entries:
+            return False
+        entry_stat = entry.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISREG(entry_stat.st_mode)
+            or entry_stat.st_uid != 0
+            or entry_stat.st_gid != 0
+            or stat.S_IMODE(entry_stat.st_mode) & 0o022
+        ):
+            return False
+
+    return True
+
+
+def _ensure_root_owned_directory(path, mode, allowed_entries=None):
+    if _is_trusted_root_directory(path, allowed_entries):
+        shutil.chown(path, "root", "root")
+        os.chmod(path, mode)
+        return
+
     if os.path.lexists(path):
         if os.path.isdir(path) and not os.path.islink(path):
             shutil.rmtree(path)
@@ -89,8 +128,79 @@ def _recreate_owned_directory(path, user, group, mode):
             os.unlink(path)
 
     os.makedirs(path, mode=mode, exist_ok=False)
-    shutil.chown(path, user, group)
+    shutil.chown(path, "root", "root")
     os.chmod(path, mode)
+
+
+def _stage_root_owned_file(path, content, mode):
+    descriptor, temporary_path = tempfile.mkstemp(
+        prefix=".amlsecscan-", dir=os.path.dirname(path)
+    )
+    try:
+        if isinstance(content, bytes):
+            with os.fdopen(descriptor, "wb") as file:
+                file.write(content)
+                file.flush()
+                os.fsync(file.fileno())
+        else:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+                file.write(content)
+                file.flush()
+                os.fsync(file.fileno())
+
+        shutil.chown(temporary_path, "root", "root")
+        os.chmod(temporary_path, mode)
+        return temporary_path
+    except Exception:
+        if os.path.lexists(temporary_path):
+            os.unlink(temporary_path)
+        raise
+
+
+def _create_backup(path):
+    descriptor, backup_path = tempfile.mkstemp(
+        prefix=".amlsecscan-backup-", dir=os.path.dirname(path)
+    )
+    os.close(descriptor)
+    os.unlink(backup_path)
+    try:
+        os.link(path, backup_path, follow_symlinks=False)
+        return backup_path
+    except Exception:
+        if os.path.lexists(backup_path):
+            os.unlink(backup_path)
+        raise
+
+
+def _write_files_atomically(files):
+    staged_files = []
+    backups = {}
+    replaced_paths = []
+    try:
+        for path, content, mode in files:
+            staged_files.append((path, _stage_root_owned_file(path, content, mode)))
+
+        for path, _ in staged_files:
+            backups[path] = _create_backup(path) if os.path.lexists(path) else None
+
+        for path, staged_path in staged_files:
+            os.replace(staged_path, path)
+            replaced_paths.append(path)
+    except Exception:
+        for path in reversed(replaced_paths):
+            backup_path = backups[path]
+            if backup_path is None:
+                os.unlink(path)
+            else:
+                os.replace(backup_path, path)
+        raise
+    finally:
+        for _, staged_path in staged_files:
+            if os.path.lexists(staged_path):
+                os.unlink(staged_path)
+        for backup_path in backups.values():
+            if backup_path is not None and os.path.lexists(backup_path):
+                os.unlink(backup_path)
 
 
 class StdOutTelemetry:
@@ -307,19 +417,8 @@ def _install(log_analytics_resource_id):
 
     _logger.debug(f"Configuration: {config}")
 
-    _logger.debug(f"Creating folder {_config_folder_path}")
-    _recreate_owned_directory(_config_folder_path, "root", "root", 0o0755)
-
-    _logger.debug(f"Creating state folder {_state_folder_path}")
-    _recreate_owned_directory(_state_folder_path, "root", "root", 0o0755)
-
-    _logger.info(f"Writing configuration file {_global_config_path}")
-    with open(_global_config_path, "wt") as file:
-        json.dump(config, file, indent=2)
-    shutil.chown(_global_config_path, "root", "root")
-    os.chmod(_global_config_path, 0o0644)
-
     _logger.info("Installing Trivy")
+    _run("apt-get update")
     _run(
         "apt-get install -y --no-install-recommends --quiet wget apt-transport-https gnupg lsb-release"
     )
@@ -332,17 +431,18 @@ def _install(log_analytics_resource_id):
     _run("apt-get update")
     _run("apt-get install -y --no-install-recommends --quiet trivy")
 
-    _logger.info(f"Writing scanner file {_installed_scanner_path}")
-    with open(_installed_scanner_path, "wb") as file:
-        file.write(scanner_source)
-    shutil.chown(_installed_scanner_path, "root", "root")
-    os.chmod(_installed_scanner_path, 0o0755)
+    _logger.debug(f"Ensuring folder {_config_folder_path}")
+    _ensure_root_owned_directory(
+        _config_folder_path,
+        0o0755,
+        {"config.json", "amlsecscan.py", "run.sh"},
+    )
+
+    _logger.debug(f"Ensuring state folder {_state_folder_path}")
+    _ensure_root_owned_directory(_state_folder_path, 0o0755)
 
     script_path = _config_folder_path + "/run.sh"
-    _logger.info(f"Writing script file {script_path}")
-    with open(script_path, "wt") as file:
-        file.write(
-            f"""#!/bin/bash
+    script = f"""#!/bin/bash
 set -e
 exec 1> >(logger -s -t AMLSECSCAN) 2>&1
 
@@ -369,19 +469,21 @@ configure_cgroup || true
 
 nice -n 19 python3 {_installed_scanner_path} "$@"
 """
-        )
-    shutil.chown(script_path, "root", "root")
-    os.chmod(script_path, 0o0755)
 
-    _logger.info(f"Writing crontab file {_cron_path}")
-    with open(_cron_path, "wt") as file:
-        file.write(
-            f"""*/10 * * * * root {script_path} heartbeat
+    cron = f"""*/10 * * * * root {script_path} heartbeat
 37 5 * * * root {script_path} scan all
 @reboot root sleep 600 && {script_path} scan all
 """
-        )
-    os.chmod(_cron_path, 0o0644)
+
+    _logger.info("Writing scanner files and CRON schedule")
+    _write_files_atomically(
+        [
+            (_global_config_path, json.dumps(config, indent=2), 0o0644),
+            (_installed_scanner_path, scanner_source, 0o0755),
+            (script_path, script, 0o0755),
+            (_cron_path, cron, 0o0644),
+        ]
+    )
 
 
 def _uninstall():
@@ -547,7 +649,9 @@ def _scan_vulnerabilities(telemetry):
         for env_name in (
             entry.name for entry in os.scandir("/anaconda/envs") if entry.is_dir()
         ):
-            requirements_path = f"{_state_folder_path}/anaconda/{env_name}/requirements.txt"
+            requirements_path = (
+                f"{_state_folder_path}/anaconda/{env_name}/requirements.txt"
+            )
             _logger.info(
                 f"Saving pip freeze of conda environment {env_name} to {requirements_path}"
             )

--- a/setup/setup-ci/security-scanner/amlsecscan.py
+++ b/setup/setup-ci/security-scanner/amlsecscan.py
@@ -10,6 +10,7 @@ import logging
 import logging.handlers
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -31,6 +32,9 @@ _azure_ml_resource_id = (
 # Configuration priority: 1) command-line parameters, 2) local config file, 3) global config file
 _config_folder_path = "/home/azureuser/.amlsecscan"
 _global_config_path = _config_folder_path + "/config.json"
+_installed_scanner_path = _config_folder_path + "/amlsecscan.py"
+_state_folder_path = "/var/lib/amlsecscan"
+_cron_path = "/etc/cron.d/amlsecscan"
 _local_config_path = os.path.abspath(os.path.splitext(__file__)[0] + ".json")
 
 
@@ -75,6 +79,18 @@ def _run(command, check=True):
             f"Error: {e}\n    stdout:\n{e.stdout}\n    stderr:\n{e.stderr}"
         )
         raise
+
+
+def _recreate_owned_directory(path, user, group, mode):
+    if os.path.lexists(path):
+        if os.path.isdir(path) and not os.path.islink(path):
+            shutil.rmtree(path)
+        else:
+            os.unlink(path)
+
+    os.makedirs(path, mode=mode, exist_ok=False)
+    shutil.chown(path, user, group)
+    os.chmod(path, mode)
 
 
 class StdOutTelemetry:
@@ -255,9 +271,8 @@ def _install(log_analytics_resource_id):
             "Installation must be performed by the root user. Please run again using sudo."
         )
 
-    _logger.debug(f"Creating folder {_config_folder_path}")
-    os.makedirs(_config_folder_path, exist_ok=True)
-    shutil.chown(_config_folder_path, "azureuser", "azureuser")
+    with open(os.path.abspath(__file__), "rb") as file:
+        scanner_source = file.read()
 
     config = {"logAnalyticsResourceId": None}
 
@@ -292,10 +307,17 @@ def _install(log_analytics_resource_id):
 
     _logger.debug(f"Configuration: {config}")
 
+    _logger.debug(f"Creating folder {_config_folder_path}")
+    _recreate_owned_directory(_config_folder_path, "root", "root", 0o0755)
+
+    _logger.debug(f"Creating state folder {_state_folder_path}")
+    _recreate_owned_directory(_state_folder_path, "root", "root", 0o0755)
+
     _logger.info(f"Writing configuration file {_global_config_path}")
     with open(_global_config_path, "wt") as file:
         json.dump(config, file, indent=2)
-    shutil.chown(_global_config_path, "azureuser", "azureuser")
+    shutil.chown(_global_config_path, "root", "root")
+    os.chmod(_global_config_path, 0o0644)
 
     _logger.info("Installing Trivy")
     _run(
@@ -309,6 +331,12 @@ def _install(log_analytics_resource_id):
     )
     _run("apt-get update")
     _run("apt-get install -y --no-install-recommends --quiet trivy")
+
+    _logger.info(f"Writing scanner file {_installed_scanner_path}")
+    with open(_installed_scanner_path, "wb") as file:
+        file.write(scanner_source)
+    shutil.chown(_installed_scanner_path, "root", "root")
+    os.chmod(_installed_scanner_path, 0o0755)
 
     script_path = _config_folder_path + "/run.sh"
     _logger.info(f"Writing script file {script_path}")
@@ -328,20 +356,21 @@ then
 fi
 echo $$ | tee /sys/fs/cgroup/cpu/amlsecscan/tasks > /dev/null
 
-nice -n 19 python3 {os.path.abspath(__file__)} $1 $2 $3 $4 $5
+nice -n 19 python3 {_installed_scanner_path} "$@"
 """
         )
+    shutil.chown(script_path, "root", "root")
     os.chmod(script_path, 0o0755)
 
-    _logger.info(f"Writing crontab file /etc/cron.d/amlsecscan")
-    with open("/etc/cron.d/amlsecscan", "wt") as file:
+    _logger.info(f"Writing crontab file {_cron_path}")
+    with open(_cron_path, "wt") as file:
         file.write(
             f"""*/10 * * * * root {script_path} heartbeat
 37 5 * * * root {script_path} scan all
 @reboot root sleep 600 && {script_path} scan all
 """
         )
-    os.chmod("/etc/cron.d/amlsecscan", 0o0644)
+    os.chmod(_cron_path, 0o0644)
 
 
 def _uninstall():
@@ -350,11 +379,14 @@ def _uninstall():
             "Uninstallation must be performed by the root user. Please run again using sudo."
         )
 
-    _logger.info(f"Deleting crontab file /etc/cron.d/amlsecscan")
-    _run("rm -f /etc/cron.d/amlsecscan")
+    _logger.info(f"Deleting crontab file {_cron_path}")
+    _run(f"rm -f {_cron_path}")
 
     _logger.info(f"Deleting folder {_config_folder_path}")
     shutil.rmtree(_config_folder_path, ignore_errors=True)
+
+    _logger.info(f"Deleting state folder {_state_folder_path}")
+    shutil.rmtree(_state_folder_path, ignore_errors=True)
 
 
 def _sanitize_log_analytics_resource_id(log_analytics_resource_id):
@@ -499,25 +531,27 @@ def _scan_vulnerabilities(telemetry):
     _send_health(telemetry, "ScanVulnerabilities", "Started")
 
     try:
-        shutil.rmtree(f"{_config_folder_path}/anaconda", ignore_errors=True)
+        os.makedirs(_state_folder_path, exist_ok=True)
+        shutil.rmtree(f"{_state_folder_path}/anaconda", ignore_errors=True)
         for env_name in (
             entry.name for entry in os.scandir("/anaconda/envs") if entry.is_dir()
         ):
+            requirements_path = f"{_state_folder_path}/anaconda/{env_name}/requirements.txt"
             _logger.info(
-                f"Saving pip freeze of conda environment {env_name} to {_config_folder_path}/anaconda/{env_name}/requirements.txt"
+                f"Saving pip freeze of conda environment {env_name} to {requirements_path}"
             )
-            os.makedirs(f"{_config_folder_path}/anaconda/{env_name}", exist_ok=True)
+            os.makedirs(os.path.dirname(requirements_path), exist_ok=True)
             _run(
-                f"/anaconda/envs/{env_name}/bin/python3 -m pip freeze > {_config_folder_path}/anaconda/{env_name}/requirements.txt"
+                f"{shlex.quote(f'/anaconda/envs/{env_name}/bin/python3')} -m pip freeze > {shlex.quote(requirements_path)}"
             )
 
         _logger.info("Running Trivy scan")
         _run(
-            f"/usr/local/bin/trivy filesystem --format json --output {_config_folder_path}/trivy.json --security-checks vuln --severity HIGH,CRITICAL --ignore-unfixed /"
+            f"/usr/local/bin/trivy filesystem --format json --output {_state_folder_path}/trivy.json --security-checks vuln --severity HIGH,CRITICAL --ignore-unfixed /"
         )
 
         findings_os, findings_python = _parse_trivy_results(
-            f"{_config_folder_path}/trivy.json"
+            f"{_state_folder_path}/trivy.json"
         )
 
         _send_assessment(

--- a/setup/setup-ci/security-scanner/amlsecscan.py
+++ b/setup/setup-ci/security-scanner/amlsecscan.py
@@ -347,14 +347,25 @@ set -e
 exec 1> >(logger -s -t AMLSECSCAN) 2>&1
 
 # Limit CPU usage to 20% and reduce priority (note: the configuration is not persisted during reboot)
-if [ ! -d /sys/fs/cgroup/cpu/amlsecscan ]
-then
-    mkdir -p /sys/fs/cgroup/cpu/amlsecscan
-    echo 100000 | tee /sys/fs/cgroup/cpu/amlsecscan/cpu.cfs_period_us > /dev/null
-    echo 20000 | tee /sys/fs/cgroup/cpu/amlsecscan/cpu.cfs_quota_us > /dev/null
-    echo 5 | tee /sys/fs/cgroup/cpu/amlsecscan/cpu.shares > /dev/null
-fi
-echo $$ | tee /sys/fs/cgroup/cpu/amlsecscan/tasks > /dev/null
+configure_cgroup() {{
+    if [ -f /sys/fs/cgroup/cgroup.controllers ]
+    then
+        cgroup_path=/sys/fs/cgroup/amlsecscan
+        mkdir -p "$cgroup_path" || return 0
+        [ -w "$cgroup_path/cpu.max" ] && echo "20000 100000" > "$cgroup_path/cpu.max"
+        [ -w "$cgroup_path/cpu.weight" ] && echo 5 > "$cgroup_path/cpu.weight"
+        [ -w "$cgroup_path/cgroup.procs" ] && echo $$ > "$cgroup_path/cgroup.procs"
+    elif [ -d /sys/fs/cgroup/cpu ]
+    then
+        cgroup_path=/sys/fs/cgroup/cpu/amlsecscan
+        mkdir -p "$cgroup_path" || return 0
+        [ -w "$cgroup_path/cpu.cfs_period_us" ] && echo 100000 > "$cgroup_path/cpu.cfs_period_us"
+        [ -w "$cgroup_path/cpu.cfs_quota_us" ] && echo 20000 > "$cgroup_path/cpu.cfs_quota_us"
+        [ -w "$cgroup_path/cpu.shares" ] && echo 5 > "$cgroup_path/cpu.shares"
+        [ -w "$cgroup_path/tasks" ] && echo $$ > "$cgroup_path/tasks"
+    fi
+}}
+configure_cgroup || true
 
 nice -n 19 python3 {_installed_scanner_path} "$@"
 """

--- a/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
+++ b/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
@@ -191,6 +191,12 @@ def test_sanitize_log_analytics_resource_id():
         )
 
 
+def test_default_scheduled_entrypoint_path_is_root_controlled():
+    assert amlsecscan._config_folder_path == "/etc/amlsecscan"
+    assert amlsecscan._installed_scanner_path == "/etc/amlsecscan/amlsecscan.py"
+    assert not amlsecscan._config_folder_path.startswith("/home/azureuser/")
+
+
 def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
     config_dir = tmp_path / "config"
     state_dir = tmp_path / "state"

--- a/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
+++ b/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
@@ -1,8 +1,9 @@
+import json
 import os
 import sys
 import pytest
 import requests
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 # Mock environment variables
 os.environ["MSI_ENDPOINT"] = "http://127.0.0.1:46808/MSI/auth"
@@ -188,6 +189,59 @@ def test_sanitize_log_analytics_resource_id():
         amlsecscan._sanitize_log_analytics_resource_id(
             "/subscriptions/d94a7037-ed50-426f-8a48-03035940fc7a/resourceGroups/WUS2/providers/Microsoft.OperationalInsights/workspaces"
         )
+
+
+def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    state_dir = tmp_path / "state"
+    cron_path = tmp_path / "cron.d" / "amlsecscan"
+    cron_path.parent.mkdir()
+
+    global_config_path = config_dir / "config.json"
+    installed_scanner_path = config_dir / "amlsecscan.py"
+    run_script_path = config_dir / "run.sh"
+
+    monkeypatch.setattr(amlsecscan, "_config_folder_path", config_dir.as_posix())
+    monkeypatch.setattr(amlsecscan, "_global_config_path", global_config_path.as_posix())
+    monkeypatch.setattr(
+        amlsecscan, "_installed_scanner_path", installed_scanner_path.as_posix()
+    )
+    monkeypatch.setattr(amlsecscan, "_state_folder_path", state_dir.as_posix())
+    monkeypatch.setattr(amlsecscan, "_cron_path", cron_path.as_posix())
+    monkeypatch.setattr(amlsecscan, "_local_config_path", (tmp_path / "missing.json").as_posix())
+    monkeypatch.setattr(amlsecscan.os, "geteuid", lambda: 0, raising=False)
+    monkeypatch.setattr(amlsecscan, "_run", lambda command, check=True: None)
+
+    log_analytics_resource_id = "/subscriptions/mock-s/resourceGroups/mock-rg/providers/Microsoft.OperationalInsights/workspaces/mock-w"
+
+    with patch.object(amlsecscan.shutil, "chown") as mock_chown:
+        amlsecscan._install(log_analytics_resource_id)
+
+    assert json.loads(global_config_path.read_text()) == {
+        "logAnalyticsResourceId": log_analytics_resource_id
+    }
+    assert installed_scanner_path.exists()
+    assert state_dir.is_dir()
+
+    run_script = run_script_path.read_text()
+    assert f"python3 {installed_scanner_path.as_posix()} \"$@\"" in run_script
+    assert os.path.abspath(amlsecscan.__file__) not in run_script
+
+    cron = cron_path.read_text()
+    assert f"root {run_script_path.as_posix()} heartbeat" in cron
+
+    mock_chown.assert_has_calls(
+        [
+            call(config_dir.as_posix(), "root", "root"),
+            call(state_dir.as_posix(), "root", "root"),
+            call(global_config_path.as_posix(), "root", "root"),
+            call(installed_scanner_path.as_posix(), "root", "root"),
+            call(run_script_path.as_posix(), "root", "root"),
+        ],
+        any_order=True,
+    )
+    for chown_call in mock_chown.call_args_list:
+        assert chown_call.args[1:] == ("root", "root")
 
 
 def test_parse_trivy_results_1():

--- a/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
+++ b/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import sys
 import pytest
 import requests
@@ -205,17 +206,36 @@ def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
     global_config_path = config_dir / "config.json"
     installed_scanner_path = config_dir / "amlsecscan.py"
     run_script_path = config_dir / "run.sh"
+    config_dir.mkdir()
+    state_dir.mkdir()
+    state_marker = state_dir / "existing-marker"
+    global_config_path.write_text("existing config")
+    installed_scanner_path.write_text("existing scanner")
+    run_script_path.write_text("existing entrypoint")
+    state_marker.write_text("keep")
 
     monkeypatch.setattr(amlsecscan, "_config_folder_path", config_dir.as_posix())
-    monkeypatch.setattr(amlsecscan, "_global_config_path", global_config_path.as_posix())
+    monkeypatch.setattr(
+        amlsecscan, "_global_config_path", global_config_path.as_posix()
+    )
     monkeypatch.setattr(
         amlsecscan, "_installed_scanner_path", installed_scanner_path.as_posix()
     )
     monkeypatch.setattr(amlsecscan, "_state_folder_path", state_dir.as_posix())
     monkeypatch.setattr(amlsecscan, "_cron_path", cron_path.as_posix())
-    monkeypatch.setattr(amlsecscan, "_local_config_path", (tmp_path / "missing.json").as_posix())
+    monkeypatch.setattr(
+        amlsecscan, "_local_config_path", (tmp_path / "missing.json").as_posix()
+    )
     monkeypatch.setattr(amlsecscan.os, "geteuid", lambda: 0, raising=False)
-    monkeypatch.setattr(amlsecscan, "_run", lambda command, check=True: None)
+    commands = []
+    monkeypatch.setattr(
+        amlsecscan, "_run", lambda command, check=True: commands.append(command)
+    )
+    monkeypatch.setattr(
+        amlsecscan,
+        "_is_trusted_root_directory",
+        lambda path, allowed_entries=None: True,
+    )
 
     log_analytics_resource_id = "/subscriptions/mock-s/resourceGroups/mock-rg/providers/Microsoft.OperationalInsights/workspaces/mock-w"
 
@@ -227,9 +247,11 @@ def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
     }
     assert installed_scanner_path.exists()
     assert state_dir.is_dir()
+    assert state_marker.read_text() == "keep"
+    assert commands[0] == "apt-get update"
 
     run_script = run_script_path.read_text()
-    assert f"python3 {installed_scanner_path.as_posix()} \"$@\"" in run_script
+    assert f'python3 {installed_scanner_path.as_posix()} "$@"' in run_script
     assert os.path.abspath(amlsecscan.__file__) not in run_script
     assert "cgroup.controllers" in run_script
     assert "cpu.max" in run_script
@@ -243,14 +265,111 @@ def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
         [
             call(config_dir.as_posix(), "root", "root"),
             call(state_dir.as_posix(), "root", "root"),
-            call(global_config_path.as_posix(), "root", "root"),
-            call(installed_scanner_path.as_posix(), "root", "root"),
-            call(run_script_path.as_posix(), "root", "root"),
         ],
         any_order=True,
     )
+    assert len(mock_chown.call_args_list) == 6
     for chown_call in mock_chown.call_args_list:
         assert chown_call.args[1:] == ("root", "root")
+    assert not list(config_dir.glob(".amlsecscan-*"))
+    assert not list(cron_path.parent.glob(".amlsecscan-*"))
+
+
+def test_untrusted_install_directory_is_recreated(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    unexpected_module = config_dir / "requests.py"
+    unexpected_module.write_text("malicious")
+
+    with patch.object(
+        amlsecscan, "_is_trusted_root_directory", return_value=False
+    ), patch.object(amlsecscan.shutil, "chown"):
+        amlsecscan._ensure_root_owned_directory(
+            config_dir.as_posix(),
+            0o0755,
+            {"config.json", "amlsecscan.py", "run.sh"},
+        )
+
+    assert config_dir.is_dir()
+    assert not unexpected_module.exists()
+
+
+def test_atomic_file_failure_restores_previous_files(tmp_path):
+    first_path = tmp_path / "first"
+    second_path = tmp_path / "second"
+    first_path.write_text("old first")
+    second_path.write_text("old second")
+    real_replace = os.replace
+
+    def fail_second_replace(source, destination):
+        if destination == second_path.as_posix():
+            raise OSError("mock replacement failure")
+        real_replace(source, destination)
+
+    with patch.object(amlsecscan.shutil, "chown"), patch.object(
+        amlsecscan.os, "replace", side_effect=fail_second_replace
+    ):
+        with pytest.raises(OSError, match="mock replacement failure"):
+            amlsecscan._write_files_atomically(
+                [
+                    (first_path.as_posix(), "new first", 0o0644),
+                    (second_path.as_posix(), "new second", 0o0644),
+                ]
+            )
+
+    assert first_path.read_text() == "old first"
+    assert second_path.read_text() == "old second"
+    assert not list(tmp_path.glob(".amlsecscan-*"))
+
+
+def test_install_failure_preserves_existing_entrypoint(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    state_dir = tmp_path / "state"
+    cron_path = tmp_path / "cron.d" / "amlsecscan"
+    config_dir.mkdir()
+    state_dir.mkdir()
+    cron_path.parent.mkdir()
+
+    global_config_path = config_dir / "config.json"
+    installed_scanner_path = config_dir / "amlsecscan.py"
+    run_script_path = config_dir / "run.sh"
+    global_config_path.write_text("existing config")
+    installed_scanner_path.write_text("existing scanner")
+    run_script_path.write_text("existing entrypoint")
+    state_marker = state_dir / "existing-state"
+    state_marker.write_text("existing state")
+    cron_path.write_text("existing cron")
+
+    monkeypatch.setattr(amlsecscan, "_config_folder_path", config_dir.as_posix())
+    monkeypatch.setattr(
+        amlsecscan, "_global_config_path", global_config_path.as_posix()
+    )
+    monkeypatch.setattr(
+        amlsecscan, "_installed_scanner_path", installed_scanner_path.as_posix()
+    )
+    monkeypatch.setattr(amlsecscan, "_state_folder_path", state_dir.as_posix())
+    monkeypatch.setattr(amlsecscan, "_cron_path", cron_path.as_posix())
+    monkeypatch.setattr(
+        amlsecscan, "_local_config_path", (tmp_path / "missing.json").as_posix()
+    )
+    monkeypatch.setattr(amlsecscan.os, "geteuid", lambda: 0, raising=False)
+
+    def fail_package_install(command, check=True):
+        raise subprocess.CalledProcessError(100, command)
+
+    monkeypatch.setattr(amlsecscan, "_run", fail_package_install)
+
+    log_analytics_resource_id = "/subscriptions/mock-s/resourceGroups/mock-rg/providers/Microsoft.OperationalInsights/workspaces/mock-w"
+
+    with patch.object(amlsecscan.shutil, "chown"):
+        with pytest.raises(subprocess.CalledProcessError):
+            amlsecscan._install(log_analytics_resource_id)
+
+    assert global_config_path.read_text() == "existing config"
+    assert installed_scanner_path.read_text() == "existing scanner"
+    assert run_script_path.read_text() == "existing entrypoint"
+    assert state_marker.read_text() == "existing state"
+    assert cron_path.read_text() == "existing cron"
 
 
 def test_parse_trivy_results_1():

--- a/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
+++ b/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
@@ -191,6 +191,11 @@ def test_sanitize_log_analytics_resource_id():
         )
 
 
+def test_default_install_path_is_root_controlled():
+    assert amlsecscan._config_folder_path == "/opt/amlsecscan"
+    assert amlsecscan._installed_scanner_path == "/opt/amlsecscan/amlsecscan.py"
+
+
 def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
     config_dir = tmp_path / "config"
     state_dir = tmp_path / "state"

--- a/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
+++ b/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
@@ -202,13 +202,17 @@ def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
     run_script_path = config_dir / "run.sh"
 
     monkeypatch.setattr(amlsecscan, "_config_folder_path", config_dir.as_posix())
-    monkeypatch.setattr(amlsecscan, "_global_config_path", global_config_path.as_posix())
+    monkeypatch.setattr(
+        amlsecscan, "_global_config_path", global_config_path.as_posix()
+    )
     monkeypatch.setattr(
         amlsecscan, "_installed_scanner_path", installed_scanner_path.as_posix()
     )
     monkeypatch.setattr(amlsecscan, "_state_folder_path", state_dir.as_posix())
     monkeypatch.setattr(amlsecscan, "_cron_path", cron_path.as_posix())
-    monkeypatch.setattr(amlsecscan, "_local_config_path", (tmp_path / "missing.json").as_posix())
+    monkeypatch.setattr(
+        amlsecscan, "_local_config_path", (tmp_path / "missing.json").as_posix()
+    )
     monkeypatch.setattr(amlsecscan.os, "geteuid", lambda: 0, raising=False)
     monkeypatch.setattr(amlsecscan, "_run", lambda command, check=True: None)
 
@@ -224,7 +228,7 @@ def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
     assert state_dir.is_dir()
 
     run_script = run_script_path.read_text()
-    assert f"python3 {installed_scanner_path.as_posix()} \"$@\"" in run_script
+    assert f'python3 {installed_scanner_path.as_posix()} "$@"' in run_script
     assert os.path.abspath(amlsecscan.__file__) not in run_script
     assert "cgroup.controllers" in run_script
     assert "cpu.max" in run_script

--- a/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
+++ b/setup/setup-ci/security-scanner/tests/test_amlsecscan.py
@@ -226,6 +226,10 @@ def test_install_writes_root_owned_entrypoint(tmp_path, monkeypatch):
     run_script = run_script_path.read_text()
     assert f"python3 {installed_scanner_path.as_posix()} \"$@\"" in run_script
     assert os.path.abspath(amlsecscan.__file__) not in run_script
+    assert "cgroup.controllers" in run_script
+    assert "cpu.max" in run_script
+    assert "cpu.cfs_quota_us" in run_script
+    assert "configure_cgroup || true" in run_script
 
     cron = cron_path.read_text()
     assert f"root {run_script_path.as_posix()} heartbeat" in cron


### PR DESCRIPTION
## Summary

Hardens the Azure ML Compute Instance security scanner installation layout so scheduled root execution does not depend on files in a user-owned directory.

This change:
- Keeps the scanner execution directory and cron entrypoint root-owned.
- Installs a root-owned copy of `amlsecscan.py` and has `run.sh` execute that trusted copy.
- Keeps `config.json` root-owned and world-readable.
- Moves generated scan artifacts to `/var/lib/amlsecscan`.
- Adds regression coverage for the hardened install layout.
- Updates scanner documentation with the new installed layout.

## Validation

```powershell
python -m py_compile .\setup\setup-ci\security-scanner\amlsecscan.py
python -m pytest .\setup\setup-ci\security-scanner\tests\test_amlsecscan.py
```

Result: `11 passed, 2 skipped`.