### PR TITLE
Fix 6c_r_iris registry pipeline by using local iris dataset input

### DIFF
--- a/cli/jobs/pipelines-with-components/basics/6c_r_iris/pipeline.yml
+++ b/cli/jobs/pipelines-with-components/basics/6c_r_iris/pipeline.yml
@@ -11,4 +11,4 @@ jobs:
     inputs:
       iris: 
         type: uri_file
-        path: https://azuremlexamples.blob.core.windows.net/datasets/iris.csv
+        path: ../../../../assets/data/example-data/iris.csv


### PR DESCRIPTION
## Summary
- replace external iris dataset URL in the 6c_r_iris pipeline sample with a repo-local iris CSV
- remove runtime dependency on azuremlexamples.blob.core.windows.net for this workflow path

## Root cause
The workflow started failing with ScriptExecution.StreamAccess.ConnectionFailure due to DNS resolution failure for azuremlexamples.blob.core.windows.net, while sample/workflow code remained unchanged.

## Changes
- updated [cli/jobs/pipelines-with-components/basics/6c_r_iris/pipeline.yml](cli/jobs/pipelines-with-components/basics/6c_r_iris/pipeline.yml) input path:
  - from: https://azuremlexamples.blob.core.windows.net/datasets/iris.csv
  - to: ../../../../assets/data/example-data/iris.csv

## Validation
- confirmed new path exists from sample working directory
- scoped to a single file and single input path change

## Notes
This is a targeted hotfix for the 6c_r_iris registry pipeline regression. A broader follow-up can migrate remaining samples away from the retired external sample host.