### PR TITLE
Fix batch notebook endpoint defaults

### DIFF
--- a/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
@@ -574,7 +574,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults = {\"deployment_name\": deployment.name}\n",
+    "endpoint.defaults = {\"deploymentName\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -584,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults['deployment_name']}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
@@ -574,7 +574,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = deployment.name\n",
+    "endpoint.defaults = {\"deployment_name\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -584,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.deployment_name}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deployment_name']}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
@@ -584,7 +584,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
+    "print(\n",
+    "    f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\"\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/custom-outputs-parquet/custom-output-batch.ipynb
@@ -584,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
+    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
@@ -488,7 +488,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint.name)\n",
-    "endpoint.defaults.deployment_name = deployment.name\n",
+    "endpoint.defaults = {\"deploymentName\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -508,7 +508,7 @@
    },
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.deployment_name}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
@@ -508,7 +508,9 @@
    },
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
+    "print(\n",
+    "    f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\"\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb
@@ -508,7 +508,7 @@
    },
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
+    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
@@ -781,7 +781,7 @@
    },
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
+    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
@@ -747,7 +747,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = deployment.name\n",
+    "endpoint.defaults = {\"deploymentName\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -781,7 +781,7 @@
    },
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.deployment_name}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/huggingface-text-summarization/text-summarization-batch.ipynb
@@ -781,7 +781,9 @@
    },
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
+    "print(\n",
+    "    f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\"\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
@@ -1215,7 +1215,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = deployment.name\n",
+    "endpoint.defaults = {\"deploymentName\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -1250,7 +1250,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "print(f\"The default deployment is {endpoint.defaults.deployment_name}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
@@ -1250,7 +1250,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
+    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-batch.ipynb
@@ -1250,7 +1250,9 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
+    "print(\n",
+    "    f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\"\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-mlflow.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-mlflow.ipynb
@@ -785,7 +785,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = mlflow_deployment.name\n",
+    "endpoint.defaults = {\"deploymentName\": mlflow_deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -803,7 +803,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.deployment_name}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-mlflow.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-mlflow.ipynb
@@ -803,7 +803,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
+    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-mlflow.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/imagenet-classifier/imagenet-classifier-mlflow.ipynb
@@ -803,7 +803,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
+    "print(\n",
+    "    f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\"\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-models/mnist-classifier/mnist-batch.ipynb
+++ b/sdk/python/endpoints/batch/deploy-models/mnist-classifier/mnist-batch.ipynb
@@ -507,7 +507,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = deployment.name\n",
+    "endpoint.defaults = {\"deploymentName\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -1250,7 +1250,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = deployment_keras.name\n",
+    "endpoint.defaults = {\"deploymentName\": deployment_keras.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },

--- a/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
@@ -669,7 +669,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
+    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
@@ -651,7 +651,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = deployment.name\n",
+    "endpoint.defaults = {\"deploymentName\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -669,7 +669,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.deployment_name}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb
@@ -669,7 +669,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
+    "print(\n",
+    "    f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\"\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
@@ -425,7 +425,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
+    "print(\n",
+    "    f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\"\n",
+    ")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
@@ -425,7 +425,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
+    "print(f\"The default deployment is {endpoint.defaults.get('deploymentName', endpoint.defaults.get('deployment_name'))}\")"
    ]
   },
   {

--- a/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
+++ b/sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb
@@ -407,7 +407,7 @@
    "outputs": [],
    "source": [
     "endpoint = ml_client.batch_endpoints.get(endpoint_name)\n",
-    "endpoint.defaults.deployment_name = deployment.name\n",
+    "endpoint.defaults = {\"deploymentName\": deployment.name}\n",
     "ml_client.batch_endpoints.begin_create_or_update(endpoint).result()"
    ]
   },
@@ -425,7 +425,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"The default deployment is {endpoint.defaults.deployment_name}\")"
+    "print(f\"The default deployment is {endpoint.defaults['deploymentName']}\")"
    ]
   },
   {

--- a/sdk/python/setup.sh
+++ b/sdk/python/setup.sh
@@ -16,7 +16,7 @@ pip install pandas
 
 # <az_ml_sdk_test_install>
 # pip install azure-ai-ml==0.1.0.b8
-pip install azure-ai-ml
+pip install https://azuresdkartifacts.z5.web.core.windows.net/python/distributions/ml-sample/6498751/azure_ai_ml-1.34.1-py3-none-any.whl || pip install azure-ai-ml
 # https://docsupport.blob.core.windows.net/ml-sample-submissions/1905732/azure_ai_ml-1.0.0-py3-none-any.whl
 # </az_ml_sdk_test_install>
 

--- a/sdk/python/setup.sh
+++ b/sdk/python/setup.sh
@@ -16,7 +16,7 @@ pip install pandas
 
 # <az_ml_sdk_test_install>
 # pip install azure-ai-ml==0.1.0.b8
-pip install https://azuresdkartifacts.z5.web.core.windows.net/python/distributions/ml-sample/6498751/azure_ai_ml-1.34.1-py3-none-any.whl || pip install azure-ai-ml
+pip install azure-ai-ml
 # https://docsupport.blob.core.windows.net/ml-sample-submissions/1905732/azure_ai_ml-1.0.0-py3-none-any.whl
 # </az_ml_sdk_test_install>
 


### PR DESCRIPTION
## Summary
- fix BatchEndpoint defaults assignment in the batch endpoint notebooks tied to IcM incidents 826916579, 826916869, 826917174, 826917463, 826917777, 826918057, 826918280, and 826918657
- use the service-compatible `deploymentName` dictionary key for `endpoint.defaults` writes
- read either `deploymentName` or `deployment_name` because SDK responses can return the snake_case key

## Validation
- validated changed notebooks parse as JSON locally
- PR validation proved `deployment_name` is rejected by the service on update, while `deploymentName` succeeds
- monitoring retriggered notebook workflows on this PR