### PR TITLE
 centralize workflow python version via AZUREML_NOTEBOOKS_PYTHON_VERSION

### DIFF
--- a/.github/workflows/automated-cleanup-resources.yml
+++ b/.github/workflows/automated-cleanup-resources.yml
@@ -24,7 +24,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: azure login
       uses: azure/login@v1
       with:

--- a/.github/workflows/automated-cleanup-resources.yml
+++ b/.github/workflows/automated-cleanup-resources.yml
@@ -24,7 +24,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: azure login
       uses: azure/login@v1
       with:

--- a/.github/workflows/bootstrapping-infra.yml
+++ b/.github/workflows/bootstrapping-infra.yml
@@ -42,7 +42,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/bootstrapping-infra.yml
+++ b/.github/workflows/bootstrapping-infra.yml
@@ -42,7 +42,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/bootstrapping-resources.yml
+++ b/.github/workflows/bootstrapping-resources.yml
@@ -25,7 +25,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/bootstrapping-resources.yml
+++ b/.github/workflows/bootstrapping-resources.yml
@@ -25,7 +25,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-component-component.yml
+++ b/.github/workflows/sdk-assets-component-component.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-component-component.yml
+++ b/.github/workflows/sdk-assets-component-component.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-data-data.yml
+++ b/.github/workflows/sdk-assets-data-data.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-data-data.yml
+++ b/.github/workflows/sdk-assets-data-data.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-data-versioning.yml
+++ b/.github/workflows/sdk-assets-data-versioning.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install --no-cache-dir -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-data-versioning.yml
+++ b/.github/workflows/sdk-assets-data-versioning.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install --no-cache-dir -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-data-working_with_mltable.yml
+++ b/.github/workflows/sdk-assets-data-working_with_mltable.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-data-working_with_mltable.yml
+++ b/.github/workflows/sdk-assets-data-working_with_mltable.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-environment-environment.yml
+++ b/.github/workflows/sdk-assets-environment-environment.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-environment-environment.yml
+++ b/.github/workflows/sdk-assets-environment-environment.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-model-model.yml
+++ b/.github/workflows/sdk-assets-model-model.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-assets-model-model.yml
+++ b/.github/workflows/sdk-assets-model-model.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-resources-connections-connections.yml
+++ b/.github/workflows/sdk-resources-connections-connections.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-resources-connections-connections.yml
+++ b/.github/workflows/sdk-resources-connections-connections.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-resources-registry-registry-create.yml
+++ b/.github/workflows/sdk-resources-registry-registry-create.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-resources-registry-registry-create.yml
+++ b/.github/workflows/sdk-resources-registry-registry-create.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-schedules-job-schedule.yml
+++ b/.github/workflows/sdk-schedules-job-schedule.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/sdk-schedules-job-schedule.yml
+++ b/.github/workflows/sdk-schedules-job-schedule.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
+++ b/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
+++ b/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
+++ b/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
+++ b/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
+++ b/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
+++ b/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
+++ b/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
+++ b/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
+++ b/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
+++ b/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
+++ b/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
+++ b/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
@@ -33,7 +33,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
@@ -33,7 +33,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
@@ -33,7 +33,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
@@ -33,7 +33,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
@@ -33,7 +33,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
@@ -33,7 +33,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login

--- a/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-train-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-train-model.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-train-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-train-model.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/.github/workflows/tutorials-get-started-notebooks-train-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-train-model.yml
@@ -34,7 +34,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
+        python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: pip install mlflow reqs

--- a/sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet/prep/prep_component.py
+++ b/sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet/prep/prep_component.py
@@ -11,7 +11,7 @@ from mldesigner import command_component, Input, Output
     description="Convert data to CSV file, and split to training and test data",
     environment=dict(
         conda_file=Path(__file__).parent / "conda.yaml",
-        image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
+        image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04",
     ),
 )
 def prepare_data_component(

--- a/sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet/score/score.yaml
+++ b/sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet/score/score.yaml
@@ -15,5 +15,5 @@ code: ./
 command: python score.py --input_data ${{inputs.input_data}} --input_model ${{inputs.input_model}} --output_result ${{outputs.output_result}}
 environment:
   conda_file: ./conda.yaml
-  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04
+  image: mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04
 

--- a/sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet/train/train_component.py
+++ b/sdk/python/jobs/pipelines/2e_image_classification_keras_minist_convnet/train/train_component.py
@@ -10,7 +10,7 @@ from mldesigner import command_component, Input, Output
     description="train image classification with keras",
     environment=dict(
         conda_file=Path(__file__).parent / "conda.yaml",
-        image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
+        image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04",
     ),
 )
 def keras_train_component(

--- a/tutorials/e2e-distributed-pytorch-image/e2e-object-classification-distributed-pytorch.ipynb
+++ b/tutorials/e2e-distributed-pytorch-image/e2e-object-classification-distributed-pytorch.ipynb
@@ -497,7 +497,7 @@
     "\n",
     "## 3.1. Connect to Azure ML using MLFlow client\n",
     "\n",
-    "Connecting to Azure ML using MLFlow requires `pip install azureml-mlflow \"mlflow<3\"` (both). You can use the `MLClient` to obtain a tracking uri to connect with the mlflow client. In the example below, we'll get all the runs related to the training experiment:"
+    "Connecting to Azure ML using MLFlow required to `pip install azureml-mlflow mlflow` (both). You can use the `MLClient` to obtain a tracking uri to connect with the mlflow client. In the example below, we'll get all the runs related to the training experiment:"
    ]
   },
   {
@@ -507,12 +507,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import subprocess\n",
-    "import sys\n",
-    "\n",
-    "# Use MLflow v2 client behavior for AML tracking compatibility in CI.\n",
-    "subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"mlflow<3\", \"-q\"])\n",
-    "\n",
     "import mlflow\n",
     "from mlflow.tracking import MlflowClient\n",
     "import matplotlib.pyplot as plt\n",

--- a/tutorials/e2e-distributed-pytorch-image/e2e-object-classification-distributed-pytorch.ipynb
+++ b/tutorials/e2e-distributed-pytorch-image/e2e-object-classification-distributed-pytorch.ipynb
@@ -497,7 +497,7 @@
     "\n",
     "## 3.1. Connect to Azure ML using MLFlow client\n",
     "\n",
-    "Connecting to Azure ML using MLFlow required to `pip install azureml-mlflow mlflow` (both). You can use the `MLClient` to obtain a tracking uri to connect with the mlflow client. In the example below, we'll get all the runs related to the training experiment:"
+    "Connecting to Azure ML using MLFlow requires `pip install azureml-mlflow \"mlflow<3\"` (both). You can use the `MLClient` to obtain a tracking uri to connect with the mlflow client. In the example below, we'll get all the runs related to the training experiment:"
    ]
   },
   {
@@ -507,6 +507,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "# Use MLflow v2 client behavior for AML tracking compatibility in CI.\n",
+    "subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"mlflow<3\", \"-q\"])\n",
+    "\n",
     "import mlflow\n",
     "from mlflow.tracking import MlflowClient\n",
     "import matplotlib.pyplot as plt\n",

--- a/tutorials/readme.py
+++ b/tutorials/readme.py
@@ -162,7 +162,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-                python-version: "${{{{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}}}"
+                python-version: "${{{{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION }}}}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt{mlflow_import}{forecast_import}
     - name: azure login

--- a/tutorials/readme.py
+++ b/tutorials/readme.py
@@ -162,7 +162,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.11"
+                python-version: "${{{{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}}}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt{mlflow_import}{forecast_import}
     - name: azure login

--- a/tutorials/readme.py
+++ b/tutorials/readme.py
@@ -162,7 +162,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with: 
-        python-version: "3.8"
+        python-version: "3.11"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt{mlflow_import}{forecast_import}
     - name: azure login


### PR DESCRIPTION
# Description

Updated selected workflow files to use AZUREML_NOTEBOOKS_PYTHON_VERSION as the single source of truth for workflow Python version.

This removes hardcoded Python version values across multiple workflow files.

This makes it easier to validate the same workflows against a different Python version when needed.

Restored the mlflow<3 snippet in the distributed PyTorch tutorial notebook.


# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
