### PR TITLE
Update ai-platform-docs CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -233,7 +233,6 @@ sdk/python/foundation-models/cohere/command_tools-langchain.ipynb @stewart-co @k
 /sdk/python/endpoints/batch/deploy-models/openai-embeddings/deploy-and-test.ipynb @Azure/AI-Platform-Docs
 /sdk/python/endpoints/batch/deploy-pipelines/batch-scoring-with-preprocessing/sdk-deploy-and-test.ipynb @Azure/AI-Platform-Docs
 /sdk/python/endpoints/batch/deploy-pipelines/hello-batch/sdk-deploy-and-test.ipynb @Azure/AI-Platform-Docs
-/sdk/python/endpoints/batch/deploy-pipelines/from-registry/sdk-deploy-and-test.ipynb @Azure/AI-Platform-Docs
 /sdk/python/endpoints/batch/deploy-pipelines/training-with-components/sdk-deploy-and-test.ipynb @Azure/AI-Platform-Docs
 /sdk/python/endpoints/online/managed/debug-online-endpoints-locally-in-visual-studio-code.ipynb @Azure/AI-Platform-Docs
 /sdk/python/endpoints/online/managed/managed-identities/online-endpoints-managed-identity-sai.ipynb @Azure/AI-Platform-Docs


### PR DESCRIPTION
Automated CODEOWNERS refresh from code-ref-monitor outputs.

Source file: CODEOWNERS-azureml-examples.txt
Entries added: 0
Entries removed: 1

This update replaces only */ai-platform-docs-owned entries and preserves all other CODEOWNERS lines.