### PR TITLE
Fix MLflow tracking links to use Studio

### DIFF
--- a/sdk/python/using-mlflow/model-management/model_management.ipynb
+++ b/sdk/python/using-mlflow/model-management/model_management.ipynb
@@ -47,6 +47,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT\"] = \"true\"\n",
+    "\n",
     "import mlflow\n",
     "from sklearn import linear_model"
    ]
@@ -187,15 +191,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import re\n",
+    "\n",
+    "\n",
+    "def get_azure_ml_studio_url(run):\n",
+    "    match = re.search(\n",
+    "        r\"subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/\"\n",
+    "        r\"Microsoft\\.MachineLearningServices/workspaces/([^/?]+)\",\n",
+    "        mlflow.get_tracking_uri(),\n",
+    "        re.IGNORECASE,\n",
+    "    )\n",
+    "    if not match:\n",
+    "        return \"https://ml.azure.com\"\n",
+    "\n",
+    "    subscription_id, resource_group, workspace_name = match.groups()\n",
+    "    workspace_id = (\n",
+    "        f\"/subscriptions/{subscription_id}/resourcegroups/{resource_group}\"\n",
+    "        f\"/workspaces/{workspace_name}\"\n",
+    "    )\n",
+    "    return f\"https://ml.azure.com/runs/{run.info.run_id}?wsid={workspace_id}\"\n",
+    "\n",
+    "\n",
     "exp = mlflow.get_experiment_by_name(experiment_name)\n",
     "last_run = mlflow.search_runs(exp.experiment_id, output_format=\"list\")[-1]\n",
-    "print(last_run.info.run_id)"
+    "studio_url = get_azure_ml_studio_url(last_run)\n",
+    "print(f\"View run in Azure Machine Learning studio: {studio_url}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The MLflow tracking URI is an API endpoint used by the MLflow client; it does not host the open-source MLflow web UI. Use the Azure Machine Learning studio URL printed above to view the run, including its metrics, parameters, and artifacts.\n",
+    "\n",
     "Once we have the run identified, we can register the model using Mlflow client:"
    ]
   },

--- a/sdk/python/using-mlflow/train-and-log/keras_mnist_with_mlflow.ipynb
+++ b/sdk/python/using-mlflow/train-and-log/keras_mnist_with_mlflow.ipynb
@@ -40,6 +40,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT\"] = \"true\"\n",
+    "\n",
     "import mlflow\n",
     "\n",
     "mlflow.set_experiment(experiment_name=\"keras-mnist-classifier\")"
@@ -250,13 +254,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run = mlflow.get_run(run.info.run_id)"
+    "import re\n",
+    "\n",
+    "\n",
+    "def get_azure_ml_studio_url(run):\n",
+    "    match = re.search(\n",
+    "        r\"subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/\"\n",
+    "        r\"Microsoft\\.MachineLearningServices/workspaces/([^/?]+)\",\n",
+    "        mlflow.get_tracking_uri(),\n",
+    "        re.IGNORECASE,\n",
+    "    )\n",
+    "    if not match:\n",
+    "        return \"https://ml.azure.com\"\n",
+    "\n",
+    "    subscription_id, resource_group, workspace_name = match.groups()\n",
+    "    workspace_id = (\n",
+    "        f\"/subscriptions/{subscription_id}/resourcegroups/{resource_group}\"\n",
+    "        f\"/workspaces/{workspace_name}\"\n",
+    "    )\n",
+    "    return f\"https://ml.azure.com/runs/{run.info.run_id}?wsid={workspace_id}\"\n",
+    "\n",
+    "\n",
+    "run = mlflow.get_run(run.info.run_id)\n",
+    "print(f\"View run in Azure Machine Learning studio: {get_azure_ml_studio_url(run)}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The MLflow tracking URI is an API endpoint used by the MLflow client; it does not host the open-source MLflow web UI. Use the Azure Machine Learning studio URL printed above to view the run, including its metrics, parameters, and artifacts.\n",
+    "\n",
     "Let's explore the parameters that got logged:"
    ]
   },

--- a/sdk/python/using-mlflow/train-and-log/xgboost_classification_mlflow.ipynb
+++ b/sdk/python/using-mlflow/train-and-log/xgboost_classification_mlflow.ipynb
@@ -25,8 +25,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import warnings\n",
     "\n",
+    "os.environ[\"MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT\"] = \"true\"\n",
     "warnings.simplefilter(\"ignore\")"
    ]
   },
@@ -283,13 +285,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run = mlflow.get_run(run.info.run_id)"
+    "import re\n",
+    "\n",
+    "\n",
+    "def get_azure_ml_studio_url(run):\n",
+    "    match = re.search(\n",
+    "        r\"subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/\"\n",
+    "        r\"Microsoft\\.MachineLearningServices/workspaces/([^/?]+)\",\n",
+    "        mlflow.get_tracking_uri(),\n",
+    "        re.IGNORECASE,\n",
+    "    )\n",
+    "    if not match:\n",
+    "        return \"https://ml.azure.com\"\n",
+    "\n",
+    "    subscription_id, resource_group, workspace_name = match.groups()\n",
+    "    workspace_id = (\n",
+    "        f\"/subscriptions/{subscription_id}/resourcegroups/{resource_group}\"\n",
+    "        f\"/workspaces/{workspace_name}\"\n",
+    "    )\n",
+    "    return f\"https://ml.azure.com/runs/{run.info.run_id}?wsid={workspace_id}\"\n",
+    "\n",
+    "\n",
+    "run = mlflow.get_run(run.info.run_id)\n",
+    "print(f\"View run in Azure Machine Learning studio: {get_azure_ml_studio_url(run)}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The MLflow tracking URI is an API endpoint used by the MLflow client; it does not host the open-source MLflow web UI. Use the Azure Machine Learning studio URL printed above to view the run, including its metrics, parameters, and artifacts.\n",
+    "\n",
     "Let's explore the parameters that got logged:"
    ]
   },

--- a/sdk/python/using-mlflow/train-and-log/xgboost_nested_runs.ipynb
+++ b/sdk/python/using-mlflow/train-and-log/xgboost_nested_runs.ipynb
@@ -25,12 +25,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import warnings\n",
     "\n",
+    "os.environ[\"MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT\"] = \"true\"\n",
     "warnings.simplefilter(\"ignore\")"
    ]
   },
@@ -662,17 +664,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "hyperopt_run = mlflow.last_active_run()"
+    "import re\n",
+    "\n",
+    "\n",
+    "def get_azure_ml_studio_url(run):\n",
+    "    match = re.search(\n",
+    "        r\"subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/\"\n",
+    "        r\"Microsoft\\.MachineLearningServices/workspaces/([^/?]+)\",\n",
+    "        mlflow.get_tracking_uri(),\n",
+    "        re.IGNORECASE,\n",
+    "    )\n",
+    "    if not match:\n",
+    "        return \"https://ml.azure.com\"\n",
+    "\n",
+    "    subscription_id, resource_group, workspace_name = match.groups()\n",
+    "    workspace_id = (\n",
+    "        f\"/subscriptions/{subscription_id}/resourcegroups/{resource_group}\"\n",
+    "        f\"/workspaces/{workspace_name}\"\n",
+    "    )\n",
+    "    return f\"https://ml.azure.com/runs/{run.info.run_id}?wsid={workspace_id}\"\n",
+    "\n",
+    "\n",
+    "hyperopt_run = mlflow.last_active_run()\n",
+    "print(\n",
+    "    \"View parent run in Azure Machine Learning studio: \"\n",
+    "    f\"{get_azure_ml_studio_url(hyperopt_run)}\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The MLflow tracking URI is an API endpoint used by the MLflow client; it does not host the open-source MLflow web UI. Use the Azure Machine Learning studio URL printed above to view the parent run and its child runs.\n",
+    "\n",
     "We can see all the child runs by using the tag `mlflow.parentRunId` that gets automatically populated by MLflow and Azure ML."
    ]
   },

--- a/sdk/python/using-mlflow/train-and-log/xgboost_service_principal.ipynb
+++ b/sdk/python/using-mlflow/train-and-log/xgboost_service_principal.ipynb
@@ -58,7 +58,8 @@
     "\n",
     "os.environ[\"AZURE_TENANT_ID\"] = \"<AZURE_TENANT_ID>\"\n",
     "os.environ[\"AZURE_CLIENT_ID\"] = \"<AZURE_CLIENT_ID>\"\n",
-    "os.environ[\"AZURE_CLIENT_SECRET\"] = \"<AZURE_CLIENT_SECRET>\""
+    "os.environ[\"AZURE_CLIENT_SECRET\"] = \"<AZURE_CLIENT_SECRET>\"\n",
+    "os.environ[\"MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT\"] = \"true\""
    ]
   },
   {
@@ -153,7 +154,7 @@
    "source": [
     "import mlflow\n",
     "\n",
-    "mlflow.set_tracking_uri = ws.mlflow_tracking_uri\n",
+    "mlflow.set_tracking_uri(ws.mlflow_tracking_uri)\n",
     "mlflow.set_experiment(experiment_name=\"heart-condition-classifier\")"
    ]
   },
@@ -386,13 +387,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run = mlflow.get_run(run.info.run_id)"
+    "import re\n",
+    "\n",
+    "\n",
+    "def get_azure_ml_studio_url(run):\n",
+    "    match = re.search(\n",
+    "        r\"subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/\"\n",
+    "        r\"Microsoft\\.MachineLearningServices/workspaces/([^/?]+)\",\n",
+    "        mlflow.get_tracking_uri(),\n",
+    "        re.IGNORECASE,\n",
+    "    )\n",
+    "    if not match:\n",
+    "        return \"https://ml.azure.com\"\n",
+    "\n",
+    "    subscription_id, resource_group, workspace_name = match.groups()\n",
+    "    workspace_id = (\n",
+    "        f\"/subscriptions/{subscription_id}/resourcegroups/{resource_group}\"\n",
+    "        f\"/workspaces/{workspace_name}\"\n",
+    "    )\n",
+    "    return f\"https://ml.azure.com/runs/{run.info.run_id}?wsid={workspace_id}\"\n",
+    "\n",
+    "\n",
+    "run = mlflow.get_run(run.info.run_id)\n",
+    "print(f\"View run in Azure Machine Learning studio: {get_azure_ml_studio_url(run)}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The MLflow tracking URI is an API endpoint used by the MLflow client; it does not host the open-source MLflow web UI. Use the Azure Machine Learning studio URL printed above to view the run, including its metrics, parameters, and artifacts.\n",
+    "\n",
     "Let's explore the parameters that got logged:"
    ]
   },


### PR DESCRIPTION
# Description
Fixes MLflow tracking links that return HTTP 404 because Azure ML does not host the MLflow UI.

Suppresses invalid MLflow-generated links.
Adds direct Azure ML Studio run links.
Clarifies that the tracking URI is an API endpoint.
Fixes the incorrect mlflow.set_tracking_uri assignment

# Checklist


- [ ] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [CLI](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
