### PR TITLE
fix: harden sample configuration and package installation

### DIFF
--- a/sdk/python/generative-ai/rag/code_first/flows/chat-with-index/setup_env.py
+++ b/sdk/python/generative-ai/rag/code_first/flows/chat-with-index/setup_env.py
@@ -4,11 +4,22 @@ from typing import Union
 from promptflow import tool
 from promptflow.connections import AzureOpenAIConnection, OpenAIConnection
 
+ALLOWED_CONFIG_KEYS = {
+    "CHAT_MODEL_DEPLOYMENT_NAME",
+    "PROMPT_TOKEN_LIMIT",
+    "MAX_COMPLETION_TOKENS",
+    "VERBOSE",
+}
+
 
 @tool
 def setup_env(connection: Union[AzureOpenAIConnection, OpenAIConnection], config: dict):
     if not connection or not config:
         return
+
+    unsupported_keys = set(config) - ALLOWED_CONFIG_KEYS
+    if unsupported_keys:
+        raise ValueError(f"Unsupported configuration keys: {sorted(unsupported_keys)}")
 
     if isinstance(connection, AzureOpenAIConnection):
         os.environ["OPENAI_API_TYPE"] = "azure"
@@ -21,7 +32,7 @@ def setup_env(connection: Union[AzureOpenAIConnection, OpenAIConnection], config
         if connection.organization is not None:
             os.environ["OPENAI_ORG_ID"] = connection.organization
 
-    for key in config:
-        os.environ[key] = str(config[key])
+    for key, value in config.items():
+        os.environ[key] = str(value)
 
     return "Ready"

--- a/setup/setup-dsvm/RStudio/Windows-Install-RStudio-opensource.ps1
+++ b/setup/setup-dsvm/RStudio/Windows-Install-RStudio-opensource.ps1
@@ -22,8 +22,7 @@
         Invoke-Expression ((New-Object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
     }
     choco feature enable --name allowGlobalConfirmation # stop the -y flag being needed for all "choco install"s
-    choco feature disable --name checksumFiles # lots of packages have no checksums, e.g. WinSDK, so allow them
     choco install -y vcredist140
 	Write-Host "#### Installing Rstudio #########"
 	C:\ProgramData\chocolatey\choco install r.studio -y
-	Write-Host "#### Completed Rstudio installtion with choco #########"
+	Write-Host "#### Completed Rstudio installation with choco #########"


### PR DESCRIPTION
# Description

This PR hardens two sample configuration and installation paths:

- Restricts the Prompt Flow `config` input to the documented configuration keys.
- Rejects unsupported keys before modifying environment variables, preventing callers from overriding connection-owned settings such as the OpenAI API endpoint or credentials.
- Removes the global Chocolatey checksum-verification bypass from the Windows RStudio installation script.

# Validation

- Confirmed the Prompt Flow defaults, batch configuration, CLI example, and SDK example use only the allowlisted keys.
- For Windows-Install-RStudio-opensource.ps1, validated on a Windows VM that RStudio installs successfully with Chocolatey checksum validation enabled; global checksumFiles disable is not required. Packages that need an exception can use `--ignore-checksums` instead of disabling checksums globally.

# Checklist


- [] I have read the contribution guidelines.
  - [General](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
  - [SDK](https://github.com/Azure/azureml-examples/blob/main/sdk/CONTRIBUTING.md)
  - [](https://github.com/Azure/azureml-examples/blob/main/cli/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] Pull request includes test coverage for the included changes.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure/azureml-examples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
