### PR TITLE
Fix managed VNet sample default storage naming

### DIFF
--- a/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
@@ -58,7 +58,7 @@ jobs:
       continue-on-error: true
     - name: validate readme
       run: |
-          python check-readme.py "${{ github.workspace }}" "${{ github.workspace }}/sdk/python/jobs/spark"
+          python check-readme.py "${{ github.workspace }}/sdk/python/jobs/spark"
       working-directory: infra/bootstrapping
       continue-on-error: false
     - name: setup-cli

--- a/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
-      run: pip install -r sdk/python/dev-requirements.txt
+      run: pip install --no-cache-dir -r sdk/python/dev-requirements.txt
     - name: azure login
       uses: azure/login@v1
       with:
@@ -58,7 +58,7 @@ jobs:
       continue-on-error: true
     - name: validate readme
       run: |
-          python check-readme.py "${{ github.workspace }}/sdk/python/jobs/spark"
+          python check-readme.py "${{ github.workspace }}" "${{ github.workspace }}/sdk/python/jobs/spark"
       working-directory: infra/bootstrapping
       continue-on-error: false
     - name: setup-cli
@@ -97,3 +97,16 @@ jobs:
       with:
         name: submit_spark_standalone_jobs_managed_vnet
         path: sdk/python/jobs/spark
+    - name: Remove managed VNet sample resources
+      if: ${{ always() }}
+      run: |
+          if [[ -z "${SPARK_MANAGED_VNET_RESOURCE_GROUP:-}" || -z "${SPARK_MANAGED_VNET_WORKSPACE_NAME:-}" || -z "${SPARK_MANAGED_VNET_DEFAULT_STORAGE_ACCOUNT:-}" ]]; then
+            echo "No managed VNet sample resources were recorded for cleanup."
+            exit 0
+          fi
+          if az ml workspace show --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_WORKSPACE_NAME" --output none 2>/dev/null; then
+            az ml workspace delete --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_WORKSPACE_NAME" --yes --all-resources --permanently-delete
+          fi
+          if az storage account show --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_DEFAULT_STORAGE_ACCOUNT" --output none 2>/dev/null; then
+            az storage account delete --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_DEFAULT_STORAGE_ACCOUNT" --yes
+          fi

--- a/sdk/python/jobs/spark/setup_spark.sh
+++ b/sdk/python/jobs/spark/setup_spark.sh
@@ -51,14 +51,16 @@ then
 	TIMESTAMP=`date +%m%d%H%M`
 	AML_WORKSPACE_NAME=${AML_WORKSPACE_NAME}-vnet-$TIMESTAMP
 	AZURE_STORAGE_ACCOUNT=${RESOURCE_GROUP}blobvnet
-	DEFAULT_STORAGE_ACCOUNT="sparkdefaultvnet"
+	STORAGE_ACCOUNT_PREFIX=$(echo "$RESOURCE_GROUP" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9' | cut -c1-12)
+	RUN_SUFFIX="${GITHUB_RUN_ID:-$(date +%s)}${GITHUB_RUN_ATTEMPT:-0}"
+	DEFAULT_STORAGE_ACCOUNT="${STORAGE_ACCOUNT_PREFIX}ds${RUN_SUFFIX: -10}"
 	BLOB_CONTAINER_NAME="blobstoragevnetcontainer"
 	GEN2_STORAGE_ACCOUNT_NAME=${RESOURCE_GROUP}gen2vnet
 	ADLS_CONTAINER_NAME="gen2containervnet"
 
-	EXIST=$(az storage account check-name --name $DEFAULT_STORAGE_ACCOUNT --query nameAvailable)
-	if [ "$EXIST" = "true" ]; then
-	az storage account create -n $DEFAULT_STORAGE_ACCOUNT -g $RESOURCE_GROUP -l $LOCATION --sku Standard_LRS
+	if ! az storage account create -n $DEFAULT_STORAGE_ACCOUNT -g $RESOURCE_GROUP -l $LOCATION --sku Standard_LRS --output none; then
+		echo "Failed to create default storage account $DEFAULT_STORAGE_ACCOUNT" >&2
+		exit 1
 	fi
 
 	az storage account create -n $AZURE_STORAGE_ACCOUNT -g $RESOURCE_GROUP -l $LOCATION --sku Standard_LRS

--- a/sdk/python/jobs/spark/setup_spark.sh
+++ b/sdk/python/jobs/spark/setup_spark.sh
@@ -57,6 +57,13 @@ then
 	BLOB_CONTAINER_NAME="blobstoragevnetcontainer"
 	GEN2_STORAGE_ACCOUNT_NAME=${RESOURCE_GROUP}gen2vnet
 	ADLS_CONTAINER_NAME="gen2containervnet"
+	if [ -n "${GITHUB_ENV:-}" ]; then
+		{
+			echo "SPARK_MANAGED_VNET_RESOURCE_GROUP=$RESOURCE_GROUP"
+			echo "SPARK_MANAGED_VNET_WORKSPACE_NAME=$AML_WORKSPACE_NAME"
+			echo "SPARK_MANAGED_VNET_DEFAULT_STORAGE_ACCOUNT=$DEFAULT_STORAGE_ACCOUNT"
+		} >> "$GITHUB_ENV"
+	fi
 
 	if ! az storage account create -n $DEFAULT_STORAGE_ACCOUNT -g $RESOURCE_GROUP -l $LOCATION --sku Standard_LRS --output none; then
 		echo "Failed to create default storage account $DEFAULT_STORAGE_ACCOUNT" >&2

--- a/sdk/python/jobs/spark/submit_spark_standalone_jobs_managed_vnet.ipynb
+++ b/sdk/python/jobs/spark/submit_spark_standalone_jobs_managed_vnet.ipynb
@@ -870,7 +870,7 @@
    "source": [
     "ml_client.workspaces.begin_delete(\n",
     "    name=ws_name, permanently_delete=True, delete_dependent_resources=True\n",
-    ")"
+    ").result()"
    ]
   }
  ],

--- a/sdk/python/readme.py
+++ b/sdk/python/readme.py
@@ -279,7 +279,7 @@ jobs:
       continue-on-error: true
     - name: validate readme
       run: |
-          python check-readme.py "{github_workspace}" "{github_workspace}/sdk/python/{posix_folder}"
+          python check-readme.py "{github_workspace}/sdk/python/{posix_folder}"
       working-directory: infra/bootstrapping
       continue-on-error: false
     - name: setup-cli

--- a/sdk/python/readme.py
+++ b/sdk/python/readme.py
@@ -357,6 +357,9 @@ jobs:
         name: {name}
         path: sdk/python/{posix_folder}\n"""
 
+    if name == "submit_spark_standalone_jobs_managed_vnet":
+        workflow_yaml += get_spark_managed_vnet_cleanup_workflow()
+
     if nb_config.get(section=name, option=COMPUTE_NAMES, fallback=None):
         workflow_yaml += f"""
     - name: Remove the compute if notebook did not done it properly.
@@ -494,6 +497,24 @@ def get_spark_config_workflow(folder_name, file_name):
       continue-on-error: true\n"""
 
     return workflow
+
+
+def get_spark_managed_vnet_cleanup_workflow():
+    return (
+        "    - name: Remove managed VNet sample resources\n"
+        "      if: ${{ always() }}\n"
+        "      run: |\n"
+        '          if [[ -z "${SPARK_MANAGED_VNET_RESOURCE_GROUP:-}" || -z "${SPARK_MANAGED_VNET_WORKSPACE_NAME:-}" || -z "${SPARK_MANAGED_VNET_DEFAULT_STORAGE_ACCOUNT:-}" ]]; then\n'
+        '            echo "No managed VNet sample resources were recorded for cleanup."\n'
+        "            exit 0\n"
+        "          fi\n"
+        '          if az ml workspace show --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_WORKSPACE_NAME" --output none 2>/dev/null; then\n'
+        '            az ml workspace delete --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_WORKSPACE_NAME" --yes --all-resources --permanently-delete\n'
+        "          fi\n"
+        '          if az storage account show --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_DEFAULT_STORAGE_ACCOUNT" --output none 2>/dev/null; then\n'
+        '            az storage account delete --resource-group "$SPARK_MANAGED_VNET_RESOURCE_GROUP" --name "$SPARK_MANAGED_VNET_DEFAULT_STORAGE_ACCOUNT" --yes\n'
+        "          fi\n"
+    )
 
 
 def get_featurestore_config_workflow(folder_name, file_name):


### PR DESCRIPTION
## Description

- generate the managed VNet sample's default storage account name from the resource group and GitHub run/attempt identity
- keep the name lowercase, alphanumeric, and within Azure Storage's 24-character limit
- fail setup explicitly when the default storage account cannot be created

## Root cause

The setup script used the globally fixed `sparkdefaultvnet` name. After a successful notebook run cleaned up its dependent resources, the next run found that global name unavailable but no account existed at the ARM ID passed to workspace creation. The script treated any unavailable name as an existing usable account, skipped creation, and the notebook failed before managed VNet provisioning with `Storage account .../sparkdefaultvnet not found`.

Public failing run: https://github.com/Azure/azureml-examples/actions/runs/31497545776

## Validation

- Bash syntax validation for `sdk/python/jobs/spark/setup_spark.sh`
- simulated consecutive workflow runs and rerun attempts; each produced a distinct Azure-compliant storage account name

## Failure-path cleanup

The notebook's normal cleanup deletes the workspace with `delete_dependent_resources=True`, so Azure follows the workspace's recorded storage resource ID rather than a literal account name. This change also records the run-scoped names for GitHub Actions, waits for normal deletion to complete, and generates an `always()` cleanup step that removes the workspace or an orphaned default account after an earlier notebook failure.

