### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -11,7 +11,7 @@ runs:
   using: 'composite'
   steps:
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/automated-cleanup-resources.yml
+++ b/.github/workflows/automated-cleanup-resources.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/bootstrapping-infra.yml
+++ b/.github/workflows/bootstrapping-infra.yml
@@ -38,15 +38,15 @@ jobs:
       debug: ${{ github.event.inputs.debug || false }}
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/bootstrapping-resources.yml
+++ b/.github/workflows/bootstrapping-resources.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-component-pipeline.yml
+++ b/.github/workflows/cli-assets-component-pipeline.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-component-train.yml
+++ b/.github/workflows/cli-assets-component-train.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-cloud-file-https.yml
+++ b/.github/workflows/cli-assets-data-cloud-file-https.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-cloud-file-wasbs.yml
+++ b/.github/workflows/cli-assets-data-cloud-file-wasbs.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-cloud-file.yml
+++ b/.github/workflows/cli-assets-data-cloud-file.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-cloud-folder-https.yml
+++ b/.github/workflows/cli-assets-data-cloud-folder-https.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-cloud-folder.yml
+++ b/.github/workflows/cli-assets-data-cloud-folder.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-cloud-mltable.yml
+++ b/.github/workflows/cli-assets-data-cloud-mltable.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-iris-csv-example.yml
+++ b/.github/workflows/cli-assets-data-iris-csv-example.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-local-file.yml
+++ b/.github/workflows/cli-assets-data-local-file.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-local-folder-sampledata.yml
+++ b/.github/workflows/cli-assets-data-local-folder-sampledata.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-local-folder.yml
+++ b/.github/workflows/cli-assets-data-local-folder.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-local-mltable.yml
+++ b/.github/workflows/cli-assets-data-local-mltable.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-data-public-file-https.yml
+++ b/.github/workflows/cli-assets-data-public-file-https.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-environment-docker-context.yml
+++ b/.github/workflows/cli-assets-environment-docker-context.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-environment-docker-image-plus-conda.yaml
+++ b/.github/workflows/cli-assets-environment-docker-image-plus-conda.yaml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-environment-docker-image.yml
+++ b/.github/workflows/cli-assets-environment-docker-image.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-model-local-file.yml
+++ b/.github/workflows/cli-assets-model-local-file.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-assets-model-local-mlflow.yml
+++ b/.github/workflows/cli-assets-model-local-mlflow.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-basic-installation-basic-installation.yml
+++ b/.github/workflows/cli-basic-installation-basic-installation.yml
@@ -26,14 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: Install latest Azure CLI
       run: |
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
     - name: Check Azure CLI version
       run: az --version
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-models-custom-outputs-parquet-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-custom-outputs-parquet-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-models-heart-classifier-mlflow-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-heart-classifier-mlflow-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-models-huggingface-text-summarization-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-huggingface-text-summarization-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-models-imagenet-classifier-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-imagenet-classifier-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-models-mnist-classifier-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-models-mnist-classifier-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-pipelines-hello-batch-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-pipelines-hello-batch-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-batch-deploy-pipelines-training-with-components-endpoint.yml
+++ b/.github/workflows/cli-endpoints-batch-deploy-pipelines-training-with-components-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-custom-container-minimal-multimodel-minimal-multimodel-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-minimal-multimodel-minimal-multimodel-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-conda-in-dockerfile-minimal-single-model-conda-in-dockerfile-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-conda-in-dockerfile-minimal-single-model-conda-in-dockerfile-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-minimal-single-model-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-minimal-single-model-minimal-single-model-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-custom-container-mlflow-multideployment-scikit-mlflow-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-mlflow-multideployment-scikit-mlflow-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-custom-container-r-multimodel-plumber-r-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-r-multimodel-plumber-r-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-custom-container-torchserve-densenet-torchserve-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-torchserve-densenet-torchserve-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-custom-container-triton-single-model-triton-cc-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-custom-container-triton-single-model-triton-cc-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-kubernetes-kubernetes-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-kubernetes-kubernetes-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-managed-sample-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-managed-sample-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-managed-vnet-mlflow-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-managed-vnet-mlflow-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-endpoints-online-managed-vnet-sample-endpoint.yml
+++ b/.github/workflows/cli-endpoints-online-managed-vnet-sample-endpoint.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-foundation-models-azure_openai-oai-v1-openai_completions_finetune.yml
+++ b/.github/workflows/cli-foundation-models-azure_openai-oai-v1-openai_completions_finetune.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-classification-task-bankmarketing-cli-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-classification-task-bankmarketing-cli-automl-classification-task-bankmarketing.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-bike-share-cli-automl-forecasting-task-bike-share.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-bike-share-cli-automl-forecasting-task-bike-share.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-orange-juice-sales-cli-automl-forecasting-orange-juice-sales.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-orange-juice-sales-cli-automl-forecasting-orange-juice-sales.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-energy-demand-cli-automl-forecasting-task-energy-demand.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-energy-demand-cli-automl-forecasting-task-energy-demand.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-github-dau-cli-automl-forecasting-task-github-dau.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-forecasting-task-github-dau-cli-automl-forecasting-task-github-dau.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items-automode.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multiclass-task-fridge-items-cli-automl-img-cls-mc-task-fridge-items.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items-automode.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-classification-multilabel-task-fridge-items-cli-automl-img-cls-ml-task-fridge-items.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items-automode.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-instance-segmentation-task-fridge-items-cli-automl-img-ins-seg-task-fridge-items.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items-automode.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items-automode.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-image-object-detection-task-fridge-items-cli-automl-img-od-task-fridge-items.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-regression-task-hardware-perf-cli-automl-regression-task-hardware-perf.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-regression-task-hardware-perf-cli-automl-regression-task-hardware-perf.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-multilabel-paper-cat-cli-automl-text-classification-multilabel-paper-cat.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-multilabel-paper-cat-cli-automl-text-classification-multilabel-paper-cat.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-newsgroup-cli-automl-text-classification-newsgroup.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-classification-newsgroup-cli-automl-text-classification-newsgroup.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-cli-automl-text-ner-conll2003.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-cli-automl-text-ner-conll2003.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-distributed-sweeping-cli-automl-text-ner-conll2003-distributed-sweeping.yml
+++ b/.github/workflows/cli-jobs-automl-standalone-jobs-cli-automl-text-ner-conll-distributed-sweeping-cli-automl-text-ner-conll2003-distributed-sweeping.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-automl-hello-automl-job-basic.yml
+++ b/.github/workflows/cli-jobs-basics-hello-automl-hello-automl-job-basic.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-code.yml
+++ b/.github/workflows/cli-jobs-basics-hello-code.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-data-uri-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-data-uri-folder.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-dataset.yml
+++ b/.github/workflows/cli-jobs-basics-hello-dataset.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-git.yml
+++ b/.github/workflows/cli-jobs-basics-hello-git.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-interactive.yml
+++ b/.github/workflows/cli-jobs-basics-hello-interactive.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-iris-datastore-file.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-datastore-file.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-iris-datastore-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-datastore-folder.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-iris-file.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-file.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-iris-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-folder.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-iris-literal.yml
+++ b/.github/workflows/cli-jobs-basics-hello-iris-literal.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-mlflow.yml
+++ b/.github/workflows/cli-jobs-basics-hello-mlflow.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-model-as-input.yml
+++ b/.github/workflows/cli-jobs-basics-hello-model-as-input.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-model-as-output.yml
+++ b/.github/workflows/cli-jobs-basics-hello-model-as-output.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-notebook.yml
+++ b/.github/workflows/cli-jobs-basics-hello-notebook.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-abc.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-abc.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-file.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-file.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-folder.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-customize-output-folder.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-default-artifacts.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-default-artifacts.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-io.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-io.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-pipeline-settings.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline-settings.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-pipeline.yml
+++ b/.github/workflows/cli-jobs-basics-hello-pipeline.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-sweep.yml
+++ b/.github/workflows/cli-jobs-basics-hello-sweep.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-world-env-var.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-env-var.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-world-input.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-input.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-world-org.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-org.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-world-output-data.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-output-data.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-world-output.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world-output.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-basics-hello-world.yml
+++ b/.github/workflows/cli-jobs-basics-hello-world.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-deepspeed-deepspeed-autotuning-job.yml
+++ b/.github/workflows/cli-jobs-deepspeed-deepspeed-autotuning-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-deepspeed-deepspeed-training-job.yml
+++ b/.github/workflows/cli-jobs-deepspeed-deepspeed-training-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-nebulaml-PyTorch_CNN_MNIST-job.yml
+++ b/.github/workflows/cli-jobs-nebulaml-PyTorch_CNN_MNIST-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-parallel-1a_oj_sales_prediction-pipeline.yml
+++ b/.github/workflows/cli-jobs-parallel-1a_oj_sales_prediction-pipeline.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-parallel-2a_iris_batch_prediction-pipeline.yml
+++ b/.github/workflows/cli-jobs-parallel-2a_iris_batch_prediction-pipeline.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-parallel-3a_mnist_batch_identification-pipeline.yml
+++ b/.github/workflows/cli-jobs-parallel-3a_mnist_batch_identification-pipeline.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-classification-task-bankmarketing-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-classification-task-bankmarketing-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-regression-housepricing-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-regression-housepricing-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-multilabel-paper-categorization-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-multilabel-paper-categorization-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-newsgroup-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-classification-newsgroup-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-ner-conll-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-cli-automl-text-ner-conll-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-image-instance-segmentation-task-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-instance-segmentation-task-fridge-items-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-image-multiclass-classification-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-multiclass-classification-fridge-items-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-image-multilabel-classification-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-multilabel-classification-fridge-items-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-automl-image-object-detection-task-fridge-items-pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-automl-image-object-detection-task-fridge-items-pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-cifar-10-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-cifar-10-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-iris-batch-prediction-using-parallel-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-iris-batch-prediction-using-parallel-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-mnist-batch-identification-using-parallel-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-mnist-batch-identification-using-parallel-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-nyc-taxi-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-nyc-taxi-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-tensorflow-image-segmentation-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-tensorflow-image-segmentation-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1a_e2e_local_components-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-1b_e2e_registered_components-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2a_basic_component-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-2b_component_with_input_output-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3a_basic_pipeline-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-3b_pipeline_with_data-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4a_local_data_input-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4b_datastore_datapath_uri-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4c_web_url_input-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-4d_data_input-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5a_env_public_docker_image-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5b_env_registered-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-5c_env_conda_file-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6a_tf_hello_world-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6b_pytorch_hello_world-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline-registry.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline-registry.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-basics-6c_r_iris-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-image_classification_with_densenet-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-image_classification_with_densenet-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-single-job-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-nyc_taxi_data_regression-single-job-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_job_with_flow_as_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_job_with_flow_as_component-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_hyperparameter_sweep-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_hyperparameter_sweep-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline.yml
+++ b/.github/workflows/cli-jobs-pipelines-with-components-pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-dask-nyctaxi-job.yml
+++ b/.github/workflows/cli-jobs-single-step-dask-nyctaxi-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-gpu_perf-gpu_perf_job.yml
+++ b/.github/workflows/cli-jobs-single-step-gpu_perf-gpu_perf_job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-julia-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-julia-iris-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-lightgbm-iris-job-sweep.yml
+++ b/.github/workflows/cli-jobs-single-step-lightgbm-iris-job-sweep.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-lightgbm-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-lightgbm-iris-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-pytorch-cifar-distributed-job.yml
+++ b/.github/workflows/cli-jobs-single-step-pytorch-cifar-distributed-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-pytorch-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-pytorch-iris-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-pytorch-word-language-model-job.yml
+++ b/.github/workflows/cli-jobs-single-step-pytorch-word-language-model-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-r-accidents-job.yml
+++ b/.github/workflows/cli-jobs-single-step-r-accidents-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-r-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-r-iris-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-diabetes-job.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-diabetes-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-docker-context.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-docker-context.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-sweep.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job-sweep.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-scikit-learn-iris-notebook-job.yml
+++ b/.github/workflows/cli-jobs-single-step-scikit-learn-iris-notebook-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-tensorflow-mnist-distributed-job.yml
+++ b/.github/workflows/cli-jobs-single-step-tensorflow-mnist-distributed-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-single-step-tensorflow-mnist-job.yml
+++ b/.github/workflows/cli-jobs-single-step-tensorflow-mnist-job.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-attached-spark-pipeline-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-pipeline-default-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-attached-spark-pipeline-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-pipeline-managed-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-attached-spark-pipeline-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-pipeline-user-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-attached-spark-standalone-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-standalone-default-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-attached-spark-standalone-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-standalone-managed-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-attached-spark-standalone-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-attached-spark-standalone-user-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-default-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-managed-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-pipeline-user-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-serverless-spark-standalone-default-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-standalone-default-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-serverless-spark-standalone-managed-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-standalone-managed-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-jobs-spark-serverless-spark-standalone-user-identity.yml
+++ b/.github/workflows/cli-jobs-spark-serverless-spark-standalone-user-identity.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-resources-compute-cluster-basic.yml
+++ b/.github/workflows/cli-resources-compute-cluster-basic.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-resources-compute-cluster-location.yml
+++ b/.github/workflows/cli-resources-compute-cluster-location.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-resources-compute-cluster-low-priority.yml
+++ b/.github/workflows/cli-resources-compute-cluster-low-priority.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-resources-compute-cluster-minimal.yml
+++ b/.github/workflows/cli-resources-compute-cluster-minimal.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-resources-compute-cluster-ssh-password.yml
+++ b/.github/workflows/cli-resources-compute-cluster-ssh-password.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-resources-compute-cluster-system-identity.yml
+++ b/.github/workflows/cli-resources-compute-cluster-system-identity.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-housing-classification-cli-responsibleaidashboard-housing-classification.yml
+++ b/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-housing-classification-cli-responsibleaidashboard-housing-classification.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-programmer-regression-cli-responsibleaidashboard-programmer-regression.yml
+++ b/.github/workflows/cli-responsible-ai-cli-responsibleaidashboard-programmer-regression-cli-responsibleaidashboard-programmer-regression.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-schedules-schedules-cron-job-schedule.yml
+++ b/.github/workflows/cli-schedules-schedules-cron-job-schedule.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-schedules-schedules-cron-with-settings-job-schedule.yml
+++ b/.github/workflows/cli-schedules-schedules-cron-with-settings-job-schedule.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-schedules-schedules-recurrence-job-schedule.yml
+++ b/.github/workflows/cli-schedules-schedules-recurrence-job-schedule.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-batch-score-rest.yml
+++ b/.github/workflows/cli-scripts-batch-score-rest.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-batch-score.yml
+++ b/.github/workflows/cli-scripts-batch-score.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       with:
         lfs: true
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-minimal-multimodel.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-minimal-multimodel.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-minimal-single-model.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-minimal-single-model.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-mlflow-multideployment-scikit.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-mlflow-multideployment-scikit.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-r-multimodel-plumber.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-r-multimodel-plumber.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two-integrated.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two-integrated.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-tfserving-half-plus-two.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-torchserve-densenet.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-torchserve-densenet.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-custom-container-triton-single-model.yml
+++ b/.github/workflows/cli-scripts-deploy-custom-container-triton-single-model.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-local-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-local-endpoint.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-sai.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-access-resource-uai.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint-ncd.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint-ncd.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-managed-online-endpoint.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-mlcompute-create_with-system-identity.yml
+++ b/.github/workflows/cli-scripts-deploy-mlcompute-create_with-system-identity.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-mlcompute-update-to-system-identity.yml
+++ b/.github/workflows/cli-scripts-deploy-mlcompute-update-to-system-identity.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-mlcompute-update-to-user-identity.yml
+++ b/.github/workflows/cli-scripts-deploy-mlcompute-update-to-user-identity.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-autoscale.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-binary-payloads.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-binary-payloads.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-inference-schema.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-inference-schema.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-keyvault.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-keyvault.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-minimal-single-model-registered.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-minimal-single-model-registered.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-openapi.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-openapi.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-vnet-mlflow.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-vnet-mlflow.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-moe-vnet.yml
+++ b/.github/workflows/cli-scripts-deploy-moe-vnet.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-rest.yml
+++ b/.github/workflows/cli-scripts-deploy-rest.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-kubernetes-online-endpoints.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
+++ b/.github/workflows/cli-scripts-deploy-safe-rollout-online-endpoints.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-deploy-triton-managed-online-endpoint.yml
+++ b/.github/workflows/cli-scripts-deploy-triton-managed-online-endpoint.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-misc.yml
+++ b/.github/workflows/cli-scripts-misc.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-mlflow-uri.yml
+++ b/.github/workflows/cli-scripts-mlflow-uri.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-train-rest.yml
+++ b/.github/workflows/cli-scripts-train-rest.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/cli-scripts-train.yml
+++ b/.github/workflows/cli-scripts-train.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/code-quality-python.yml
+++ b/.github/workflows/code-quality-python.yml
@@ -8,8 +8,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.9"
       - run: pip install -r dev-requirements.txt

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,8 +14,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.9"
       - name: Check Pull Request Size

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       with:
         fetch-depth: 0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.9"
     - name: pip install

--- a/.github/workflows/nyc_taxi_data_regression-env_train.yml
+++ b/.github/workflows/nyc_taxi_data_regression-env_train.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-data-using-registry.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
+++ b/.github/workflows/sdk-assets-assets-in-registry-share-models-components-environments.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-component-component.yml
+++ b/.github/workflows/sdk-assets-component-component.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-data-data.yml
+++ b/.github/workflows/sdk-assets-data-data.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-data-versioning.yml
+++ b/.github/workflows/sdk-assets-data-versioning.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install --no-cache-dir -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-data-working_with_mltable.yml
+++ b/.github/workflows/sdk-assets-data-working_with_mltable.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-environment-environment.yml
+++ b/.github/workflows/sdk-assets-environment-environment.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-assets-model-model.yml
+++ b/.github/workflows/sdk-assets-model-model.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-basic-installation-basic-installation.yml
+++ b/.github/workflows/sdk-basic-installation-basic-installation.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install --no-cache-dir -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-custom-outputs-parquet-custom-output-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-custom-outputs-parquet-custom-output-batch.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-heart-classifier-mlflow-mlflow-for-batch-tabular.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-heart-classifier-mlflow-mlflow-for-batch-tabular.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-huggingface-text-summarization-text-summarization-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-huggingface-text-summarization-text-summarization-batch.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-batch.yml
@@ -30,17 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       with:
         lfs: true
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-mlflow.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-imagenet-classifier-imagenet-classifier-mlflow.yml
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       with:
         lfs: true
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -43,7 +43,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-models-mnist-classifier-mnist-batch.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-models-mnist-classifier-mnist-batch.yml
@@ -30,17 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       with:
         lfs: true
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-sdk-deploy-and-test.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-pipelines-batch-scoring-with-preprocessing-sdk-deploy-and-test.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-pipelines-from-registry-sdk-deploy-and-test.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-pipelines-from-registry-sdk-deploy-and-test.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.11' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/endpoints/batch/deploy-pipelines/from-registry/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-pipelines-hello-batch-sdk-deploy-and-test.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-pipelines-hello-batch-sdk-deploy-and-test.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-batch-deploy-pipelines-training-with-components-sdk-deploy-and-test.yml
+++ b/.github/workflows/sdk-endpoints-batch-deploy-pipelines-training-with-components-sdk-deploy-and-test.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container-multimodel.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-online-endpoints-custom-container.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
+++ b/.github/workflows/sdk-endpoints-online-custom-container-triton-online-endpoints-triton-cc.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-safe-rollout.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-kubernetes-kubernetes-online-endpoints-simple-deployment.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-sai.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-managed-identities-online-endpoints-managed-identity-uai.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-binary-payloads.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-inference-schema.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-keyvault.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-multimodel.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-openapi.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-safe-rollout.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
+++ b/.github/workflows/sdk-endpoints-online-managed-online-endpoints-simple-deployment.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model-with-script.yml
+++ b/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model-with-script.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
+++ b/.github/workflows/sdk-endpoints-online-mlflow-online-endpoints-deploy-mlflow-model.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
+++ b/.github/workflows/sdk-endpoints-online-triton-single-model-online-endpoints-triton.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-foundation-models-azure_openai-oai-v1-openai_completions_finetune.yml
+++ b/.github/workflows/sdk-foundation-models-azure_openai-oai-v1-openai_completions_finetune.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-foundation-models-system-distillation-nli-distillation_chat_completion.yml
+++ b/.github/workflows/sdk-foundation-models-system-distillation-nli-distillation_chat_completion.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install --no-cache-dir -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry.yml
+++ b/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry.yml
@@ -32,15 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry_new_model.yml
+++ b/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry_new_model.yml
@@ -29,15 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry_new_model_image_tasks.yml
+++ b/.github/workflows/sdk-foundation-models-system-import-import_model_into_registry_new_model_image_tasks.yml
@@ -29,15 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-classification-task-bankmarketing-automl-classification-task-bankmarketing.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-distributed-tcn-automl-forecasting-distributed-tcn.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-distributed-tcn-automl-forecasting-distributed-tcn.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-github-dau-auto-ml-forecasting-github-dau.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -43,7 +43,7 @@ jobs:
     - name: pip install forecasting reqs
       run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-orange-juice-sales-automl-forecasting-orange-juice-sales-mlflow.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -43,7 +43,7 @@ jobs:
     - name: pip install forecasting reqs
       run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-experiment-settings.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-experiment-settings.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install forecasting reqs
       run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-run.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-recipes-univariate-automl-forecasting-recipe-univariate-run.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -43,7 +43,7 @@ jobs:
     - name: pip install forecasting reqs
       run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-bike-share-auto-ml-forecasting-bike-share.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -43,7 +43,7 @@ jobs:
     - name: pip install forecasting reqs
       run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced-mlflow.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -43,7 +43,7 @@ jobs:
     - name: pip install forecasting reqs
       run: pip install -r sdk/python/forecasting-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-forecasting-task-energy-demand-automl-forecasting-task-energy-demand-advanced.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multiclass-task-fridge-items-automl-image-classification-multiclass-task-fridge-items.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-classification-multilabel-task-fridge-items-automl-image-classification-multilabel-task-fridge-items.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-instance-segmentation-task-fridge-items-automl-image-instance-segmentation-task-fridge-items.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-automl-image-object-detection-task-fridge-items.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-image-object-detection-task-fridge-items-batch-scoring-image-object-detection-batch-scoring-non-mlflow-model.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment-mlflow.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multiclass-task-sentiment-analysis-automl-nlp-multiclass-sentiment.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-classification-multilabel-task-paper-categorization-automl-nlp-multilabel-paper-cat.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-automl-nlp-text-ner-task.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-nlp-text-named-entity-recognition-task-distributed-sweeping-automl-nlp-text-ner-task-distributed-with-sweeping.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
+++ b/.github/workflows/sdk-jobs-automl-standalone-jobs-automl-regression-task-hardware-performance-automl-regression-task-hardware-performance.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-configuration.yml
+++ b/.github/workflows/sdk-jobs-configuration.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-migration-aml-command-job-to-foundry-migrate-command-job-to-foundry.yml
+++ b/.github/workflows/sdk-jobs-migration-aml-command-job-to-foundry-migrate-command-job-to-foundry.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install --no-cache-dir -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-parallel-1a_oj_sales_prediction-oj_sales_prediction.yml
+++ b/.github/workflows/sdk-jobs-parallel-1a_oj_sales_prediction-oj_sales_prediction.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-parallel-2a_iris_batch_prediction-iris_batch_prediction.yml
+++ b/.github/workflows/sdk-jobs-parallel-2a_iris_batch_prediction-iris_batch_prediction.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-parallel-3a_mnist_batch_identification-mnist_batch_prediction.yml
+++ b/.github/workflows/sdk-jobs-parallel-3a_mnist_batch_identification-mnist_batch_prediction.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1a_pipeline_with_components_from_yaml-pipeline_with_components_from_yaml.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1b_pipeline_with_python_function_components-pipeline_with_python_function_components.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1c_pipeline_with_hyperparameter_sweep-pipeline_with_hyperparameter_sweep.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1d_pipeline_with_non_python_components-pipeline_with_non_python_components.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1e_pipeline_with_registered_components-pipeline_with_registered_components.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1g_pipeline_with_parallel_nodes-pipeline_with_parallel_nodes.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-classification-bankmarketing-in-pipeline-automl-classification-bankmarketing-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-forecasting-in-pipeline-automl-forecasting-in-pipeline.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multiclass-in-pipeline-automl-image-classification-multiclass-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-classification-multilabel-in-pipeline-automl-image-classification-multilabel-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-instance-segmentation-in-pipeline-automl-image-instance-segmentation-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-image-object-detection-in-pipeline-automl-image-object-detection-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-regression-house-pricing-in-pipeline-automl-regression-house-pricing-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-in-pipeline-automl-text-classification-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-in-pipeline-automl-text-classification-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-in-pipeline-automl-text-classification-multilabel-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-classification-multilabel-in-pipeline-automl-text-classification-multilabel-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1h_automl_in_pipeline-automl-text-ner-named-entity-recognition-in-pipeline-automl-text-ner-named-entity-recognition-in-pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1i_pipeline_with_spark_nodes-pipeline_with_spark_nodes.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component-nyc_taxi_data_regression_with_pipeline_component.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1j_pipeline_with_pipeline_component-pipeline_with_train_eval_pipeline_component-pipeline_with_train_eval_pipeline_component.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
+++ b/.github/workflows/sdk-jobs-pipelines-1l_flow_in_pipeline-flow_in_pipeline.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2a_train_mnist_with_tensorflow-train_mnist_with_tensorflow.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2b_train_cifar_10_with_pytorch-train_cifar_10_with_pytorch.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2c_nyc_taxi_data_regression-nyc_taxi_data_regression.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2d_image_classification_with_densenet-image_classification_with_densenet.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
+++ b/.github/workflows/sdk-jobs-pipelines-2e_image_classification_keras_minist_convnet-image_classification_keras_minist_convnet.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-pipelines-stepsequence-pipeline_with_step_sequence_dummy_dependencies.yml
+++ b/.github/workflows/sdk-jobs-pipelines-stepsequence-pipeline_with_step_sequence_dummy_dependencies.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
     - name: setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
+++ b/.github/workflows/sdk-jobs-single-step-lightgbm-iris-lightgbm-iris-sweep.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-distributed-cifar10.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-distributed-training-distributed-cifar10.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
+++ b/.github/workflows/sdk-jobs-single-step-pytorch-train-hyperparameter-tune-deploy-with-pytorch-train-hyperparameter-tune-deploy-with-pytorch.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
+++ b/.github/workflows/sdk-jobs-single-step-tensorflow-mnist-distributed-tensorflow-mnist-distributed.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-spark-automation-run_interactive_session_notebook.yml
+++ b/.github/workflows/sdk-jobs-spark-automation-run_interactive_session_notebook.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-spark-submit_spark_pipeline_jobs.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_pipeline_jobs.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
+++ b/.github/workflows/sdk-jobs-spark-submit_spark_standalone_jobs_managed_vnet.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-resources-compute-attach_manage_spark_pools.yml
+++ b/.github/workflows/sdk-resources-compute-attach_manage_spark_pools.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-resources-compute-compute.yml
+++ b/.github/workflows/sdk-resources-compute-compute.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-resources-connections-connections.yml
+++ b/.github/workflows/sdk-resources-connections-connections.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-resources-registry-registry-create.yml
+++ b/.github/workflows/sdk-resources-registry-registry-create.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-resources-workspace-workspace.yml
+++ b/.github/workflows/sdk-resources-workspace-workspace.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-mlflow-deployment-with-explanations-mlflow-deployment-with-explanations.yml
+++ b/.github/workflows/sdk-responsible-ai-mlflow-deployment-with-explanations-mlflow-deployment-with-explanations.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-decision-making-responsibleaidashboard-diabetes-decision-making.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-diabetes-regression-model-debugging-responsibleaidashboard-diabetes-regression-model-debugging.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-finance-loan-classification-responsibleaidashboard-finance-loan-classification.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-finance-loan-classification-responsibleaidashboard-finance-loan-classification.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-healthcare-covid-classification-responsibleaidashboard-healthcare-covid-classification.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-healthcare-covid-classification-responsibleaidashboard-healthcare-covid-classification.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-classification-model-debugging-responsibleaidashboard-housing-classification-model-debugging.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-housing-decision-making-responsibleaidashboard-housing-decision-making.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
+++ b/.github/workflows/sdk-responsible-ai-tabular-responsibleaidashboard-programmer-regression-model-debugging-responsibleaidashboard-programmer-regression-model-debugging.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
@@ -41,7 +41,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-schedules-job-schedule.yml
+++ b/.github/workflows/sdk-schedules-job-schedule.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-using-mltable-delimited-files-example-delimited-files-example.yml
+++ b/.github/workflows/sdk-using-mltable-delimited-files-example-delimited-files-example.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-using-mltable-delta-lake-example-delta-lake-example.yml
+++ b/.github/workflows/sdk-using-mltable-delta-lake-example-delta-lake-example.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-using-mltable-from-paths-example-from-paths-example.yml
+++ b/.github/workflows/sdk-using-mltable-from-paths-example-from-paths-example.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-using-mltable-local-to-cloud-mltable-local-to-cloud.yml
+++ b/.github/workflows/sdk-using-mltable-local-to-cloud-mltable-local-to-cloud.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/sdk-using-mltable-quickstart-mltable-quickstart.yml
+++ b/.github/workflows/sdk-using-mltable-quickstart-mltable-quickstart.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: "3.10"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
+++ b/.github/workflows/tutorials-azureml-getting-started-azureml-getting-started-studio.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
+++ b/.github/workflows/tutorials-azureml-in-a-day-azureml-in-a-day.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
+++ b/.github/workflows/tutorials-e2e-distributed-pytorch-image-e2e-object-classification-distributed-pytorch.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
+++ b/.github/workflows/tutorials-e2e-ds-experience-e2e-ml-workflow.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-cloud-workstation.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-deploy-model.yml
@@ -29,15 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-explore-data.yml
@@ -29,15 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
       run: pip install -r sdk/python/dev-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-pipeline.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-quickstart.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}

--- a/.github/workflows/tutorials-get-started-notebooks-train-model.yml
+++ b/.github/workflows/tutorials-get-started-notebooks-train-model.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with: 
         python-version: "${{ vars.AZUREML_NOTEBOOKS_PYTHON_VERSION || '3.13' }}"
     - name: pip install notebook reqs
@@ -40,7 +40,7 @@ jobs:
     - name: pip install mlflow reqs
       run: pip install -r sdk/python/mlflow-requirements.txt
     - name: azure login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ secrets.OIDC_AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.OIDC_AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
